### PR TITLE
feat: store anime title on room creation for OGP

### DIFF
--- a/api/tests.py
+++ b/api/tests.py
@@ -4,6 +4,8 @@ import pytest
 from rest_framework import status
 from rest_framework.test import APIClient, APITestCase
 
+from streamer.factories import AnimeRoomFactory
+
 
 class TestVersionCheckAPI(APITestCase):
     def setUp(self) -> None:
@@ -73,3 +75,30 @@ class TestVersionCheckAPI(APITestCase):
         get_params = {"version": "1000.0.0"}
         response = self.client.get(self.endpoint, get_params)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+class TestAnimeStoreLobbyResolveAPI(APITestCase):
+    def setUp(self) -> None:
+        self.client = APIClient()
+
+    def endpoint(self, room_id) -> str:
+        return f"/api/v1/anime-store/lobby/{room_id}"
+
+    @pytest.mark.django_db
+    def test_lobby_resolve_ok_200(self):
+        """ルームが存在する場合、redirect_url と保存済みタイトルを返すことを確認"""
+        room = AnimeRoomFactory(part_id="654321", title="鬼滅の刃 - 第1話 - 残酷")
+        response = self.client.get(self.endpoint(room.room_id))
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["part_id"] == "654321"
+        assert response.data["room_id"] == str(room.room_id)
+        assert response.data["title"] == "鬼滅の刃 - 第1話 - 残酷"
+        assert "partId=654321" in response.data["redirect_url"]
+
+    @pytest.mark.django_db
+    def test_lobby_resolve_not_found_404(self):
+        """存在しないルーム ID では 404 が返ることを確認"""
+        import uuid
+
+        response = self.client.get(self.endpoint(uuid.uuid4()))
+        assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/api/views.py
+++ b/api/views.py
@@ -270,6 +270,7 @@ class AnimeStoreLobbyResolveAPI(APIView):
                 "redirect_url": base_url + url_param,
                 "part_id": anime_room.part_id,
                 "room_id": str(room_id),
+                "title": anime_room.title,
             },
             status=status.HTTP_200_OK,
         )

--- a/streamer/admin.py
+++ b/streamer/admin.py
@@ -27,7 +27,14 @@ class LogicalDeletionModelAdmin(admin.ModelAdmin):
 
 @admin.register(AnimeRoom)
 class AnimeRoomAdmin(LogicalDeletionModelAdmin):
-    list_display = ("room_id", "part_id", "num_people", "created_at", "deleted_at")
+    list_display = (
+        "room_id",
+        "title",
+        "part_id",
+        "num_people",
+        "created_at",
+        "deleted_at",
+    )
 
 
 @admin.register(AnimeUser)

--- a/streamer/consumers.py
+++ b/streamer/consumers.py
@@ -100,9 +100,9 @@ class AnimePartyConsumer(GenericAsyncAPIConsumer):
         await self.leave_party()
 
     @action()
-    async def create(self, part_id, user_name, **kwargs):
+    async def create(self, part_id, user_name, title="", **kwargs):
         # create room
-        self.anime_room = await self.database_create_room(part_id=part_id)
+        self.anime_room = await self.database_create_room(part_id=part_id, title=title)
         # create user
         self.anime_user = await self.database_create_user(
             user_name=user_name,
@@ -423,17 +423,18 @@ class AnimePartyConsumer(GenericAsyncAPIConsumer):
         self.anime_user.save()
 
     @database_sync_to_async
-    def database_create_room(self, part_id: str):
+    def database_create_room(self, part_id: str, title: str = ""):
         """データベース上にルームを作成する
         クライアント側でルーム作成が押された場合に呼び出される
 
         Args:
             part_id ([str]): 現在視聴している動画のID(dアニメストアが発行)
+            title ([str]): 視聴中アニメのタイトル(拡張機能がページ DOM から取得)
 
         Returns:
             AnimeRoom: 作成したルームのオブジェクト
         """
-        return AnimeRoom.objects.create(part_id=part_id)
+        return AnimeRoom.objects.create(part_id=part_id, title=title)
 
     @database_sync_to_async
     def database_update_room_part_id(self, part_id: str):

--- a/streamer/factories.py
+++ b/streamer/factories.py
@@ -11,6 +11,7 @@ class AnimeRoomFactory(factory.django.DjangoModelFactory):
     num_people = factory.fuzzy.FuzzyInteger(5, 10)
     sum_people = factory.fuzzy.FuzzyInteger(10, 20)
     part_id = "123456"
+    title = factory.Faker("sentence", nb_words=3)
     updated_at = factory.Faker("date")
     created_at = factory.Faker("date")
 

--- a/streamer/models.py
+++ b/streamer/models.py
@@ -11,6 +11,9 @@ class AnimeRoom(LogicalDeletionMixin):
     num_people = models.PositiveSmallIntegerField(default=1)
     sum_people = models.PositiveSmallIntegerField(default=1)
     part_id = models.CharField(max_length=16)
+    # 視聴中アニメのタイトル。ルーム作成時に拡張機能がページ DOM から取得して
+    # 一度だけ送信する（以降は更新しない）。OGP 等の表示に使う。
+    title = models.CharField(max_length=255, blank=True, default="")
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 

--- a/streamer/tests.py
+++ b/streamer/tests.py
@@ -29,11 +29,13 @@ class TestAnimePartyConsumer(TransactionTestCase):
         connected, subprotocol = await communicator.connect()
         assert connected
         user_name1 = "user_name1"
+        title1 = "鬼滅の刃 - 第1話 - 残酷"
         await communicator.send_json_to(
             {
                 "action": "create",
                 "user_name": user_name1,
                 "part_id": "123456",
+                "title": title1,
                 "request_id": 100,
             }
         )
@@ -44,6 +46,9 @@ class TestAnimePartyConsumer(TransactionTestCase):
         assert self.anime_user_exist(response["user"]["user_id"])
         # roomがデータベースに作られていることを確認
         assert self.anime_room_exist(response["room_id"])
+        # ルーム作成時に送られたタイトルが保存されていることを確認
+        room = await self.get_anime_room(response["room_id"])
+        assert room.title == title1
         await communicator.disconnect()
 
     @pytest.mark.django_db(transaction=True)


### PR DESCRIPTION
## What
Persist the currently-playing anime title on `AnimeRoom`, captured **once at room creation**, so the frontend can render rich Open Graph cards for room links.

## Changes
- `AnimeRoom.title` (`CharField(max_length=255, blank=True, default="")`)
- `create` WebSocket action accepts an optional `title` (defaults to `""`)
- `database_create_room` saves it
- Lobby resolve API returns `title`
- admin list_display, factory, and tests updated (`create` saves title; lobby returns it)

## Backward compatibility
- Old extensions that don't send `title` keep working (`create(..., title="")`, and `**kwargs` absorbs the extra field on the old server).
- The field is additive; the lobby response simply gains a key.

## Migrations
This repo gitignores `migrations/`; run `makemigrations streamer` + `migrate` on deploy to add the `title` column (the new column is required for room creation to succeed).

## Tests
`uv run pytest` → 11 passed (incl. new title + lobby tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)