### PR TITLE
ci: bump pyproject version and tag from version input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,29 +1,53 @@
 name: Release
 
+# d-party モノレポ root の release ワークフローから統一バージョンを受け取って起動される。
+# pyproject.toml の version を書き換えて main へコミットし、タグ + GitHub Release を作る。
+
 on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Next Version"
+        description: "Release version (X.Y.Z)"
         required: true
         default: "x.y.z"
       release_note:
         description: "release note"
         required: false
+
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
+        with:
+          ref: main
+
+      - name: Bump version and commit
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ github.event.inputs.version }}
+        run: |
+          set -euo pipefail
+          python3 - <<'EOF'
+          import os, re
+          v = os.environ["VERSION"]
+          path = "pyproject.toml"
+          s = open(path, encoding="utf-8").read()
+          s = re.sub(r'(?m)^version\s*=\s*".*"$', f'version = "{v}"', s, count=1)
+          open(path, "w", encoding="utf-8").write(s)
+          EOF
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add pyproject.toml
+          git commit -m "chore: bump version to v${VERSION} [skip ci]"
+          git push origin HEAD:main
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ github.event.inputs.version }}
-          release_name: Release v${{ github.event.inputs.version }}
-          body: |
-            ${{ github.event.inputs.release_note }}
-          draft: false
-          prerelease: false
+          name: Release v${{ github.event.inputs.version }}
+          body: ${{ github.event.inputs.release_note }}
+          generate_release_notes: true
+          target_commitish: main


### PR DESCRIPTION
d-party モノレポ root の統一 release ワークフローから呼び出される形に変更。

- `version` (X.Y.Z) 入力で `pyproject.toml` の version を書き換えて main へコミット
- タグ + GitHub Release を `softprops/action-gh-release@v2` で作成（旧 `actions/create-release@v1` から更新）

🤖 Generated with [Claude Code](https://claude.com/claude-code)