### PR TITLE
fix: close ghost rooms/users on startup and repair cron env

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,13 +2,37 @@
 set -e
 
 # Schedule the retention cleanup via system cron (replaces django-crontab).
-# manage.py loads the env files itself, so the job needs no extra environment.
+# cron runs with a minimal PATH (no /opt/venv/bin), so use the venv python
+# explicitly. manage.py loads the env files itself.
 CRON_SCHEDULE="${CRON_SCHEDULE:-0 0 * * *}"
-echo "$CRON_SCHEDULE cd /usr/src/app && python manage.py cleanup >> /var/log/cron.log 2>&1" > /etc/cron.d/d-party-cleanup
+PYTHON_BIN="$(command -v python)"
+# cron は親プロセスの環境変数を引き継がないため、settings.py が参照する DEBUG
+# などのコンテナ env を取りこぼす。コンテナ起動時の env をスナップショットして
+# おき、cron ジョブから source する。
+ENV_SNAPSHOT=/etc/cron.d/d-party-env.sh
+{
+    echo "#!/bin/sh"
+    # 値に空白等が含まれてもよいよう、各値をシェル用にクォートする。
+    env | awk -F= 'NF>=2 {
+        key=$1
+        val=substr($0, length(key)+2)
+        gsub(/'\''/, "'\''\\'\'''\''", val)
+        printf "export %s='\''%s'\''\n", key, val
+    }'
+} > "$ENV_SNAPSHOT"
+chmod 0644 "$ENV_SNAPSHOT"
+{
+    echo "PATH=/opt/venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+    echo "$CRON_SCHEDULE root . $ENV_SNAPSHOT; cd /usr/src/app && $PYTHON_BIN manage.py cleanup >> /var/log/cron.log 2>&1"
+} > /etc/cron.d/d-party-cleanup
 chmod 0644 /etc/cron.d/d-party-cleanup
-crontab /etc/cron.d/d-party-cleanup
 touch /var/log/cron.log
 cron
+
+# Close any rooms/users that were left "alive" by the previous process. The
+# WebSocket session state lives only in the Django process, so without this
+# the /api/.../alive endpoints would keep counting ghost sessions forever.
+python manage.py close_active_sessions || true
 
 if [ "$DEBUG" = "1" ]; then
     python manage.py runserver 0.0.0.0:8000

--- a/streamer/management/commands/close_active_sessions.py
+++ b/streamer/management/commands/close_active_sessions.py
@@ -1,0 +1,29 @@
+"""Close any rooms / users that are still marked alive at startup.
+
+Channels の WebSocket セッションはプロセス内 (`AnimePartyConsumer`) にのみ存在
+するため、Django プロセス（コンテナ）が落ちると ``disconnect`` が呼ばれず
+``AnimeRoom`` / ``AnimeUser`` が ``alive`` のまま残る。次回コンテナ起動時に
+これらを論理削除しておかないと、統計 API（``alive`` 件数）に幽霊セッションが
+残り続けてしまう。
+
+冪等な操作なので、起動毎に無条件で実行してよい。
+"""
+
+from django.core.management.base import BaseCommand
+
+from streamer.models import AnimeRoom, AnimeUser
+
+
+class Command(BaseCommand):
+    help = "Logically delete all AnimeRoom / AnimeUser rows still marked alive."
+
+    def handle(self, *args, **options):
+        users = AnimeUser.objects.alive().count()
+        rooms = AnimeRoom.objects.alive().count()
+        AnimeUser.objects.alive().delete()
+        AnimeRoom.objects.alive().delete()
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"closed {users} alive user(s) and {rooms} alive room(s)"
+            )
+        )


### PR DESCRIPTION
## 概要

Django コンテナを作り直すと、その時接続中だった `AnimeUser` / `AnimeRoom` が `alive` のまま残り、統計 API（`/api/.../alive`）に幽霊セッションとして計上され続ける問題を修正する。

合わせて、コンテナ内の `cron` で動いているはずの retention cleanup ジョブが起動以降 1 度も成功していなかった問題も修正する。

## 変更

- **起動時クローズ**: `streamer/management/commands/close_active_sessions.py` を追加し、`AnimeUser` / `AnimeRoom` の `alive` を一括で論理削除する（冪等）。`entrypoint.sh` が runserver/gunicorn を起動する直前に呼ぶ。
- **cron 修復**:
  - cron の最小 PATH には `/opt/venv/bin` が無く `python: not found` で毎分失敗していたため、venv の絶対パス `/opt/venv/bin/python` を使うようにした。
  - cron は親プロセスの env を継承しないため `settings.py` の `os.environ["DEBUG"]` で `KeyError` になっていた。コンテナ起動時の env を `/etc/cron.d/d-party-env.sh` にスナップショットし、ジョブから `source` して解決。

## 動作確認

ローカル (`docker compose`) で再起動して確認:

```
django  | closed 90 alive user(s) and 101 alive room(s)
...
/var/log/cron.log:
  ran animeuser_auto_hard_delete
  ran animereaction_auto_hard_delete
```
