### PR TITLE
chore: bump Python to 3.14 to align with dev container

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ WebSocket（`/anime-store/party/`）を Django へ振り分けます。
 
 | 項目 | 採用 |
 |---|---|
-| 言語 | Python 3.13 |
+| 言語 | Python 3.14 |
 | フレームワーク | Django 5.2 (LTS) · Channels 4 · DRF · djangochannelsrestframework |
 | ASGI | gunicorn + `uvicorn-worker`（本番） / `runserver`（dev, DEBUG=1） |
 | DB | **PostgreSQL 16**（`django-prometheus` 経由で計測） |
@@ -59,7 +59,7 @@ WebSocket（`/anime-store/party/`）を Django へ振り分けます。
 backend/   ← リポジトリ直下が django プロジェクト
   pyproject.toml          uv（依存・ruff・pytest 設定）
   uv.lock
-  Dockerfile              python:3.13-slim + uv（venv は /opt/venv）
+  Dockerfile              python:3.14-slim + uv（venv は /opt/venv）
   .dockerignore           イメージから dev/CI 用ファイルを除外
   entrypoint.sh           cron 登録 → runserver / gunicorn
   gunicorn.conf.py        uvicorn-worker

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # below references a previously defined FROM alias (hadolint DL3022).
 FROM ghcr.io/astral-sh/uv:0.9 AS uv
 
-FROM python:3.13-slim-bookworm
+FROM python:3.14-slim-bookworm
 
 COPY --from=uv /uv /uvx /bin/
 


### PR DESCRIPTION
## 概要

dev container は Python 3.14（3.14.6）で動作しているのに対し、本番 `Dockerfile` の
ベースイメージが `python:3.13-slim` のままで版数が分かれていた。dev/本番を揃えるため
ベースイメージを **`python:3.14-slim-bookworm`** に更新する。

## 変更点

- `Dockerfile`: `python:3.13-slim-bookworm` → `python:3.14-slim-bookworm`
- `AGENTS.md`: Stack 表とレイアウトの Python 版数記述を 3.14 に同期

## 補足

- `requires-python = ">=3.13"` は floor として維持（3.13 でも動作可）。
- ローカルで `docker compose build` し、イメージが **Python 3.14.6** で起動・`uv sync --frozen`
  が通ること、および WebSocket 同時視聴の負荷試験（k6）が
  `room_setup_success 100% / ws_errors 0 / サーバ側エラー 0` で通ることを確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)