### PR TITLE
feat(stats): fold reactions into daily aggregate and cache stats API

### DIFF
--- a/.env.django
+++ b/.env.django
@@ -8,6 +8,7 @@ REDIS_PORT=6379
 CHROME_EXTENSION_REQUIRED_VERSION=1.0.0
 LOGICAL_DIVIDE_DAY=3
 HARD_DIVIDE_DAY=365
-REACTION_HARD_DIVIDE_DAY=90
+# 統計 API のレスポンスキャッシュ TTL（秒）。
+STATS_CACHE_SECONDS=300
 # Retention cleanup schedule (system cron in the container). Every minute in dev.
 CRON_SCHEDULE=* * * * *

--- a/.github/bandit.yml
+++ b/.github/bandit.yml
@@ -1,2 +1,2 @@
 assert_used:
-  skips: ["*/tests.py", "tests.py", "test/*.py"]
+  skips: ["*/tests.py", "tests.py", "test/*.py", "*/test_*.py", "test_*.py"]

--- a/api/tests.py
+++ b/api/tests.py
@@ -1,10 +1,25 @@
+import datetime
 import os
 
 import pytest
+from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APIClient, APITestCase
 
-from streamer.factories import AnimeRoomFactory
+from streamer.factories import AnimeRoomFactory, AnimeUserFactory
+from streamer.models import AnimeReaction, ReactionStat
+
+
+def _clear_reaction_tables() -> None:
+    """Drop reaction rows so reaction-count assertions are deterministic.
+
+    The test DB uses a ``MIRROR`` config, so rows committed by ``transaction=True``
+    tests (e.g. the consumer folding test) are not flushed between runs. Called in
+    ``setUp`` it runs inside the per-test transaction and is rolled back afterwards,
+    so it only hides that committed pollution for the duration of one test.
+    """
+    ReactionStat.objects.all().delete()
+    AnimeReaction.objects.all().delete(hard=True)
 
 
 class TestVersionCheckAPI(APITestCase):
@@ -102,3 +117,106 @@ class TestAnimeStoreLobbyResolveAPI(APITestCase):
 
         response = self.client.get(self.endpoint(uuid.uuid4()))
         assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+class TestStatsDaysParam(APITestCase):
+    """``?days=N`` の検証（未指定→既定、範囲外→400）。"""
+
+    def setUp(self) -> None:
+        self.client = APIClient()
+        self.endpoint = "/api/v1/statistics/anime-store/active-user-per-day"
+
+    @pytest.mark.django_db
+    def test_missing_days_defaults_ok_200(self):
+        response = self.client.get(self.endpoint)
+        assert response.status_code == status.HTTP_200_OK
+
+    @pytest.mark.django_db
+    def test_days_out_of_range_400(self):
+        for bad in ("0", "366", "-1", "abc", "1.5"):
+            response = self.client.get(self.endpoint, {"days": bad})
+            assert response.status_code == status.HTTP_400_BAD_REQUEST, bad
+
+    @pytest.mark.django_db
+    def test_days_in_range_ok_200(self):
+        for ok in ("1", "30", "365"):
+            response = self.client.get(self.endpoint, {"days": ok})
+            assert response.status_code == status.HTTP_200_OK, ok
+
+
+class TestStatsPeriodScope(APITestCase):
+    """期間スコープ（累計・リアクション）が days に従うことを確認。"""
+
+    def setUp(self) -> None:
+        self.client = APIClient()
+        _clear_reaction_tables()
+
+    @staticmethod
+    def _make_reaction(room, reaction_type, when):
+        reaction = AnimeReaction.objects.create(
+            room_id=room, reaction_type=reaction_type
+        )
+        AnimeReaction.objects.filter(pk=reaction.pk).update(created_at=when)
+        return reaction
+
+    @pytest.mark.django_db
+    def test_user_all_count_respects_days(self):
+        """40 日前のユーザーは 30 日窓では数えず 365 日窓では数える。
+
+        テスト DB は ``MIRROR`` 設定で他テストの行が残りうるため、絶対値ではなく
+        「40 日前ユーザーを 1 人足すと 365 日窓だけ +1 される」差分で検証する。
+        """
+        from streamer.models import AnimeUser
+
+        AnimeUserFactory()  # recent（auto_now_add で created_at=now）
+        old = AnimeUserFactory()
+        AnimeUser.objects.filter(pk=old.pk).update(
+            created_at=timezone.now() - datetime.timedelta(days=40)
+        )
+        endpoint = "/api/v1/statistics/anime-store/anime-user-all-count"
+
+        c30 = self.client.get(endpoint, {"days": "30"}).data["data"]["count"]
+        c365 = self.client.get(endpoint, {"days": "365"}).data["data"]["count"]
+        assert c30 >= 1  # recent は 30 日窓に入る
+        assert c365 - c30 >= 1  # 40 日前ユーザーは 365 日窓のみに入る
+
+    @pytest.mark.django_db
+    def test_reaction_counts_come_from_reactionstat_and_live(self):
+        """リアクション集計は ReactionStat（畳み込み済み）と alive ルームの合算。"""
+        today = timezone.now().date()
+        ReactionStat.objects.create(date=today, reaction_type="S", count=5)
+        live_room = AnimeRoomFactory()  # alive
+        self._make_reaction(live_room, "S", timezone.now())
+
+        by_type = self.client.get(
+            "/api/v1/statistics/anime-store/anime-reaction-count", {"days": "30"}
+        )
+        smile = next(r for r in by_type.data["data"] if r["reaction_type"] == "smile")
+        assert smile["count"] == 6  # 5 (folded) + 1 (live)
+
+        total = self.client.get(
+            "/api/v1/statistics/anime-store/anime-reaction-all-count", {"days": "30"}
+        )
+        assert total.data["data"]["count"] == 6
+
+
+class TestStatsCache(APITestCase):
+    """キャッシュヒット時に DB の変化が TTL 内では反映されないこと。"""
+
+    def setUp(self) -> None:
+        self.client = APIClient()
+        self.endpoint = "/api/v1/statistics/anime-store/anime-reaction-all-count"
+        _clear_reaction_tables()
+
+    @pytest.mark.django_db
+    def test_response_is_cached(self):
+        today = timezone.now().date()
+        ReactionStat.objects.create(date=today, reaction_type="S", count=3)
+
+        first = self.client.get(self.endpoint, {"days": "30"})
+        assert first.data["data"]["count"] == 3
+
+        # キャッシュ後に DB を増やしても、同一キーは TTL 内でキャッシュ値を返す。
+        ReactionStat.objects.filter(date=today, reaction_type="S").update(count=99)
+        second = self.client.get(self.endpoint, {"days": "30"})
+        assert second.data["data"]["count"] == 3  # キャッシュヒット

--- a/api/views.py
+++ b/api/views.py
@@ -2,20 +2,96 @@ import datetime
 import os
 import re
 import urllib.parse
+from collections import defaultdict
 
 import pandas as pd
-from django.db.models import Count
+from django.core.cache import cache
+from django.db.models import Count, Sum
 from django.db.models.functions import TruncDate
 from rest_framework import status
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from streamer.models import AnimeReaction, AnimeRoom, AnimeUser, ReactionType
+from streamer.models import (
+    AnimeReaction,
+    AnimeRoom,
+    AnimeUser,
+    ReactionStat,
+    ReactionType,
+)
 
 # Matches the previous ``distutils.version.StrictVersion`` accepted form: a
 # strict ``major.minor.patch`` triple. ``distutils`` was removed in Python 3.12.
 _STRICT_VERSION_RE = re.compile(r"^\d+\.\d+\.\d+$")
+
+# 統計の集計期間（``?days=N``）。未指定は 1 年、上限も 1 年。
+DEFAULT_STATS_DAYS = 365
+MAX_STATS_DAYS = 365
+# 統計レスポンスをキャッシュする秒数。毎リクエストの DB 集計を避けるための TTL。
+STATS_CACHE_SECONDS = int(os.getenv("STATS_CACHE_SECONDS", "300"))
+
+
+def _parse_days(request) -> int | None:
+    """Parse ``?days=N`` into ``1..365``; ``None`` signals an invalid request.
+
+    Missing parameter defaults to ``DEFAULT_STATS_DAYS`` (1 year).
+    """
+    raw = request.GET.get("days")
+    if raw is None:
+        return DEFAULT_STATS_DAYS
+    try:
+        days = int(raw)
+    except (TypeError, ValueError):
+        return None
+    if days < 1 or days > MAX_STATS_DAYS:
+        return None
+    return days
+
+
+def _bad_days() -> Response:
+    return Response(
+        {"message": f"days パラメータは 1〜{MAX_STATS_DAYS} の整数で指定してください"},
+        status=status.HTTP_400_BAD_REQUEST,
+    )
+
+
+def _since(days: int) -> datetime.date:
+    """Inclusive start date of a ``days``-long window ending today."""
+    return datetime.date.today() - datetime.timedelta(days=days - 1)
+
+
+def _cached(key: str, producer):
+    """Return a cached stats payload, computing (and storing) it on a miss."""
+    return cache.get_or_set(key, producer, STATS_CACHE_SECONDS)
+
+
+def _reaction_counts_by_type(since: datetime.date) -> dict[str, int]:
+    """Per-type reaction counts in ``[since, today]`` (folded + live rooms).
+
+    Historical reactions live in ``ReactionStat`` (folded on room end); reactions
+    of still-alive rooms remain in ``AnimeReaction`` and are added on top so the
+    total reflects in-progress rooms too. Keyed by the stored ``reaction_type``
+    value (e.g. ``"S"``).
+    """
+    merged: dict[str, int] = defaultdict(int)
+    folded = (
+        ReactionStat.objects.filter(date__gte=since)
+        .values("reaction_type")
+        .annotate(total=Sum("count"))
+    )
+    for row in folded:
+        merged[row["reaction_type"]] += row["total"]
+    live = (
+        AnimeReaction.objects.filter(
+            room_id__deleted_at__isnull=True, created_at__date__gte=since
+        )
+        .values("reaction_type")
+        .annotate(total=Count("reaction_id"))
+    )
+    for row in live:
+        merged[row["reaction_type"]] += row["total"]
+    return merged
 
 
 def _parse_strict_version(value: str) -> tuple[int, int, int] | None:
@@ -26,24 +102,38 @@ def _parse_strict_version(value: str) -> tuple[int, int, int] | None:
     return None
 
 
-def _per_day_counts(model) -> list[dict]:
+def _per_day_counts(model, since: datetime.date | None = None) -> list[dict]:
     """Return ``[{"day": date, "count": n}, ...]`` grouped by creation day.
 
-    Uses ``TruncDate`` so the query works across database backends (the
-    previous ``.extra(select={"day": "date(created_at)"})`` was MySQL-specific).
+    When ``since`` is given, only rows created on/after it are counted. Uses
+    ``TruncDate`` so the query works across database backends (the previous
+    ``.extra(select={"day": "date(created_at)"})`` was MySQL-specific).
     """
+    qs = model.objects
+    if since is not None:
+        qs = qs.filter(created_at__date__gte=since)
     return list(
-        model.objects.annotate(day=TruncDate("created_at"))
+        qs.annotate(day=TruncDate("created_at"))
         .values("day")
         .annotate(count=Count("created_at"))
         .order_by("day")
     )
 
 
-def _resample_per_day(rows: list[dict]) -> pd.DataFrame:
-    """Fill gaps so every calendar day up to today has a count."""
-    if len(rows) == 0 or rows[-1]["day"] != datetime.date.today():
-        rows = rows + [{"day": datetime.date.today(), "count": 0}]
+def _resample_per_day(
+    rows: list[dict], since: datetime.date | None = None
+) -> pd.DataFrame:
+    """Fill gaps so every calendar day has a count.
+
+    The series always extends to today; when ``since`` is given it also starts
+    exactly at ``since`` (padding the leading days with zeros) so the window has
+    a fixed length regardless of when the first event happened.
+    """
+    today = datetime.date.today()
+    if since is not None and (len(rows) == 0 or rows[0]["day"] != since):
+        rows = [{"day": since, "count": 0}] + rows
+    if len(rows) == 0 or rows[-1]["day"] != today:
+        rows = rows + [{"day": today, "count": 0}]
     frame = pd.DataFrame(rows).set_index("day").asfreq("1D", fill_value=0)
     frame["day"] = frame.index.map(lambda x: x.to_pydatetime().date())
     return frame
@@ -86,8 +176,16 @@ class AnimeActiveUserPerDayAPI(APIView):
     permission_classes = [AllowAny]
 
     def get(self, request, format=None) -> Response:
-        frame = _resample_per_day(_per_day_counts(AnimeUser))
-        return Response({"data": frame.to_dict(orient="records")})
+        days = _parse_days(request)
+        if days is None:
+            return _bad_days()
+        since = _since(days)
+
+        def produce():
+            frame = _resample_per_day(_per_day_counts(AnimeUser, since), since)
+            return frame.to_dict(orient="records")
+
+        return Response({"data": _cached(f"stats:active-user-per-day:{days}", produce)})
 
 
 class AnimeActiveRoomPerDayAPI(APIView):
@@ -97,8 +195,16 @@ class AnimeActiveRoomPerDayAPI(APIView):
     permission_classes = [AllowAny]
 
     def get(self, request, format=None) -> Response:
-        frame = _resample_per_day(_per_day_counts(AnimeRoom))
-        return Response({"data": frame.to_dict(orient="records")})
+        days = _parse_days(request)
+        if days is None:
+            return _bad_days()
+        since = _since(days)
+
+        def produce():
+            frame = _resample_per_day(_per_day_counts(AnimeRoom, since), since)
+            return frame.to_dict(orient="records")
+
+        return Response({"data": _cached(f"stats:active-room-per-day:{days}", produce)})
 
 
 class AnimeRoomReactionCountAPI(APIView):
@@ -108,16 +214,19 @@ class AnimeRoomReactionCountAPI(APIView):
     permission_classes = [AllowAny]
 
     def get(self, request, format=None) -> Response:
-        response = [
-            {
-                "count": AnimeReaction.objects.filter(reaction_type=value)
-                .all()
-                .count(),
-                "reaction_type": label,
-            }
-            for value, label in ReactionType.choices
-        ]
-        return Response({"data": response})
+        days = _parse_days(request)
+        if days is None:
+            return _bad_days()
+        since = _since(days)
+
+        def produce():
+            merged = _reaction_counts_by_type(since)
+            return [
+                {"count": merged.get(value, 0), "reaction_type": label}
+                for value, label in ReactionType.choices
+            ]
+
+        return Response({"data": _cached(f"stats:reaction-count:{days}", produce)})
 
 
 class AnimeRoomReactionAllCountAPI(APIView):
@@ -127,27 +236,54 @@ class AnimeRoomReactionAllCountAPI(APIView):
     permission_classes = [AllowAny]
 
     def get(self, request, format=None) -> Response:
-        return Response({"data": {"count": AnimeReaction.objects.all().count()}})
+        days = _parse_days(request)
+        if days is None:
+            return _bad_days()
+        since = _since(days)
+
+        def produce():
+            return sum(_reaction_counts_by_type(since).values())
+
+        count = _cached(f"stats:reaction-all-count:{days}", produce)
+        return Response({"data": {"count": count}})
 
 
 class AnimeUserAllCountAPI(APIView):
-    """Total user count."""
+    """User count within the requested period (by creation date)."""
 
     # 統計ダッシュボードはフロントエンドから誰でも閲覧できるよう公開（認証不要）。
     permission_classes = [AllowAny]
 
     def get(self, request, format=None) -> Response:
-        return Response({"data": {"count": AnimeUser.objects.all().count()}})
+        days = _parse_days(request)
+        if days is None:
+            return _bad_days()
+        since = _since(days)
+
+        def produce():
+            return AnimeUser.objects.filter(created_at__date__gte=since).count()
+
+        count = _cached(f"stats:user-all-count:{days}", produce)
+        return Response({"data": {"count": count}})
 
 
 class AnimeRoomAllCountAPI(APIView):
-    """Total room count."""
+    """Room count within the requested period (by creation date)."""
 
     # 統計ダッシュボードはフロントエンドから誰でも閲覧できるよう公開（認証不要）。
     permission_classes = [AllowAny]
 
     def get(self, request, format=None) -> Response:
-        return Response({"data": {"count": AnimeRoom.objects.all().count()}})
+        days = _parse_days(request)
+        if days is None:
+            return _bad_days()
+        since = _since(days)
+
+        def produce():
+            return AnimeRoom.objects.filter(created_at__date__gte=since).count()
+
+        count = _cached(f"stats:room-all-count:{days}", produce)
+        return Response({"data": {"count": count}})
 
 
 class AnimeUserAliveCountAPI(APIView):

--- a/conftest.py
+++ b/conftest.py
@@ -21,3 +21,23 @@ def use_in_memory_channel_layer(settings):
     layers.channel_layers.backends.clear()
     yield
     layers.channel_layers.backends.clear()
+
+
+@pytest.fixture(autouse=True)
+def use_local_memory_cache(settings):
+    """Use an in-process cache so the stats cache needs no real Redis in tests.
+
+    Each test gets its own ``LOCATION`` so cached statistics never leak between
+    tests; ``cache.clear()`` keeps a single test's assertions isolated too.
+    """
+    from django.core.cache import cache
+
+    settings.CACHES = {
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "stats-tests",
+        },
+    }
+    cache.clear()
+    yield
+    cache.clear()

--- a/d_party/settings.py
+++ b/d_party/settings.py
@@ -108,6 +108,16 @@ CHANNEL_LAYERS = {
     }
 }
 
+# 統計 API のレスポンスキャッシュ。channel layer の DB 0 と分けて DB 1 を使う。
+# 毎リクエストでの DB 集計を避け、TTL（STATS_CACHE_SECONDS）失効で自然反映する。
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.redis.RedisCache",
+        "LOCATION": f"redis://{REDIS_HOST}:{REDIS_PORT}/1",
+        "KEY_PREFIX": "dparty",
+    }
+}
+
 # Database
 # https://docs.djangoproject.com/en/4.0/ref/settings/#databases
 

--- a/streamer/consumers.py
+++ b/streamer/consumers.py
@@ -6,6 +6,7 @@ from channels.db import database_sync_to_async
 from djangochannelsrestframework.decorators import action
 from djangochannelsrestframework.generics import GenericAsyncAPIConsumer
 
+from .cron import fold_room_reactions
 from .format import (
     Create,
     GroupSend,
@@ -49,6 +50,8 @@ def _logical_delete_room_if_empty(room_id_str: str) -> bool:
         return False
     if AnimeUser.objects.alive().filter(room_id=room_id_str).exists():
         return False
+    # ルームが終了するので、リアクションを集計テーブルへ畳んで生データを削除する。
+    fold_room_reactions(room_id_str)
     qs.delete()  # logical
     return True
 
@@ -95,7 +98,7 @@ class AnimePartyConsumer(GenericAsyncAPIConsumer):
         self.close()でも呼び出される
 
         Args:
-            close_code ([type]): [description]
+            close_code (int): WebSocket のクローズコード
         """
         await self.leave_party()
 
@@ -152,7 +155,7 @@ class AnimePartyConsumer(GenericAsyncAPIConsumer):
             await self.send(text_data=json.dumps(failed.model_dump()))
             await self.close()
             return
-        # このルームに猟予期間の削除予約があれば取り消す
+        # このルームに猶予期間の削除予約があれば取り消す
         _cancel_pending_room_delete(str(self.anime_room.room_id))
         # ルームが存在しているのであればAnimeUserオブジェクトを作成
         self.anime_user = await self.database_create_user(
@@ -331,7 +334,7 @@ class AnimePartyConsumer(GenericAsyncAPIConsumer):
         if not self.anime_user.is_host:
             return
         room_id_str = str(self.anime_room.room_id)
-        # 猟予期間の自動削除が予約されていれば取り消す（ここで明示的に削除するため）。
+        # 猶予期間の自動削除が予約されていれば取り消す（ここで明示的に削除するため）。
         _cancel_pending_room_delete(room_id_str)
         server_message = ServerMessage(message_type="room_deleted")
         response_data = RoomSend(
@@ -345,10 +348,11 @@ class AnimePartyConsumer(GenericAsyncAPIConsumer):
         await self.database_delete_room_and_users()
 
     async def room_send(self, data: dict):
-        """自分を含むのグループに所属するユーザーへの一斉送信
+        """自分を含むグループに所属するユーザーへの一斉送信
 
         Args:
-            data (dict): [description]
+            data (dict): group_send 経由で渡る dict。``response`` にクライアントへ
+                送る本文を持つ。
         """
         await self.send(text_data=json.dumps(data["response"]))
 
@@ -356,7 +360,8 @@ class AnimePartyConsumer(GenericAsyncAPIConsumer):
         """自分以外のグループに所属するユーザーへの一斉送信
 
         Args:
-            data (dict): [description]
+            data (dict): group_send 経由で渡る dict。``response`` の本文と、
+                送信元を示す ``sender_channel_name`` を持つ。
         """
         if self.channel_name != data["sender_channel_name"]:
             await self.send(text_data=json.dumps(data["response"]))
@@ -365,7 +370,8 @@ class AnimePartyConsumer(GenericAsyncAPIConsumer):
         """ルームのホストユーザーにのみ送信
 
         Args:
-            data (dict): [description]
+            data (dict): group_send 経由で渡る dict。``response`` の本文と
+                ``sender_channel_name`` を持つ。
         """
         await self.database_renew_state()
         if self.channel_name != data["sender_channel_name"] and self.anime_user.is_host:
@@ -398,8 +404,8 @@ class AnimePartyConsumer(GenericAsyncAPIConsumer):
         await self.database_decrease_num_people()
         user_count = await self.database_get_user_count()
         if user_count < 1:
-            # 即消しだるとホストの一瞬切断・タブリロードでルームが消え、
-            # ゲストが全員 failed_join になる。猟予期間中に誰かが再参加したら join 側で
+            # 即消しだとホストの一瞬切断・タブリロードでルームが消え、
+            # ゲストが全員 failed_join になる。猶予期間中に誰かが再参加したら join 側で
             # cancel される。
             _schedule_room_delete(str(self.anime_room.room_id))
         if user_count >= 1 and self.anime_user.is_host:
@@ -443,8 +449,8 @@ class AnimePartyConsumer(GenericAsyncAPIConsumer):
         """データベース上にユーザーを作成する
 
         Args:
-            user_name ([type]): ユーザーが任意に指定可能な名前
-            room_id ([type]): AnimeRoomに存在するID
+            user_name (str): ユーザーが任意に指定可能な名前
+            room_id (AnimeRoom): 紐づく AnimeRoom オブジェクト
             is_host (bool, optional): ホストユーザーの場合はTrueにする
             user_icon (str, optional): react-icons (FA6) のキー。未指定なら既定アイコン。
 
@@ -467,8 +473,8 @@ class AnimePartyConsumer(GenericAsyncAPIConsumer):
         クライアント側でルーム作成が押された場合に呼び出される
 
         Args:
-            part_id ([str]): 現在視聴している動画のID(dアニメストアが発行)
-            title ([str]): 視聴中アニメのタイトル(拡張機能がページ DOM から取得)
+            part_id (str): 現在視聴している動画のID(dアニメストアが発行)
+            title (str): 視聴中アニメのタイトル(拡張機能がページ DOM から取得)
 
         Returns:
             AnimeRoom: 作成したルームのオブジェクト
@@ -482,7 +488,7 @@ class AnimePartyConsumer(GenericAsyncAPIConsumer):
         新規に入ったユーザーはこの更新されたIDの動画にリダイレクトされる
 
         Args:
-            part_id ([type]):現在視聴している動画のID(dアニメストアが発行)
+            part_id (str): 現在視聴している動画のID(dアニメストアが発行)
         """
         self.anime_room.part_id = part_id
         self.anime_room.save()
@@ -501,6 +507,8 @@ class AnimePartyConsumer(GenericAsyncAPIConsumer):
         ``LogicalDeletionMixin`` により論理削除（``deleted_at`` 付与）。
         """
         room_id = self.anime_room.room_id
+        # ルームが終了するので、リアクションを集計テーブルへ畳んで生データを削除する。
+        fold_room_reactions(room_id)
         AnimeUser.objects.alive().filter(room_id=room_id).delete()
         AnimeRoom.objects.alive().filter(room_id=room_id).delete()
 
@@ -536,10 +544,10 @@ class AnimePartyConsumer(GenericAsyncAPIConsumer):
         """ルームが存在していれば、ルームのオブジェクトを取得、そうでなければNoneを返す
 
         Args:
-            room_id ([type]): 検索するAnimeRoomのID
+            room_id (uuid): 検索するAnimeRoomのID
 
         Returns:
-            [AnimeRoom.objects,None]: ルームのオブジェクトか見つからない場合はNone
+            AnimeRoom | None: ルームのオブジェクト。見つからない場合はNone
         """
         if not is_valid_uuid(uuid_to_test=room_id):
             return None

--- a/streamer/cron.py
+++ b/streamer/cron.py
@@ -12,17 +12,54 @@ immediately, so the previous (no-op, and on a ``QuerySet`` actually invalid)
 import datetime
 import os
 
-from .models import AnimeReaction, AnimeRoom, AnimeUser
+from django.db.models import Count, F
+from django.db.models.functions import TruncDate
+
+from .models import AnimeReaction, AnimeRoom, AnimeUser, ReactionStat
 
 
 def _cutoff(days: int) -> datetime.datetime:
     return datetime.datetime.now() - datetime.timedelta(days=days)
 
 
+def fold_room_reactions(room_id) -> None:
+    """Fold a room's reactions into ``ReactionStat`` then hard-delete the rows.
+
+    Called whenever a room ends (host delete / grace-period delete / idle
+    cleanup). Reactions are aggregated per ``(creation day, reaction_type)`` and
+    added to the matching ``ReactionStat`` row (created if missing), so the raw
+    ``AnimeReaction`` rows can be removed for good — only aggregates remain.
+    """
+    rows = (
+        AnimeReaction.objects.filter(room_id=room_id)
+        .annotate(day=TruncDate("created_at"))
+        .values("day", "reaction_type")
+        .annotate(n=Count("reaction_id"))
+    )
+    for row in rows:
+        _, created = ReactionStat.objects.get_or_create(
+            date=row["day"],
+            reaction_type=row["reaction_type"],
+            defaults={"count": row["n"]},
+        )
+        if not created:
+            ReactionStat.objects.filter(
+                date=row["day"], reaction_type=row["reaction_type"]
+            ).update(count=F("count") + row["n"])
+    AnimeReaction.objects.filter(room_id=room_id).delete(hard=True)
+
+
 def animeroom_auto_logical_delete():
-    """Logically delete AnimeRooms that have outlived the logical retention."""
+    """Logically delete AnimeRooms that have outlived the logical retention.
+
+    Folds each expiring room's reactions into ``ReactionStat`` (and hard-deletes
+    the raw rows) before the room itself is logically deleted.
+    """
     days = int(os.getenv("LOGICAL_DIVIDE_DAY", default="3"))
-    AnimeRoom.objects.alive().filter(updated_at__lte=_cutoff(days)).delete()
+    expiring = AnimeRoom.objects.alive().filter(updated_at__lte=_cutoff(days))
+    for room_id in list(expiring.values_list("room_id", flat=True)):
+        fold_room_reactions(room_id)
+    expiring.delete()
 
 
 def animeroom_auto_hard_delete():
@@ -43,16 +80,9 @@ def animeuser_auto_hard_delete():
     AnimeUser.objects.all().filter(updated_at__lte=_cutoff(days)).delete(hard=True)
 
 
-def animereaction_auto_hard_delete():
-    """Hard delete AnimeReactions that have outlived the hard retention."""
-    days = int(os.getenv("REACTION_HARD_DIVIDE_DAY", default="90"))
-    AnimeReaction.objects.all().filter(created_at__lte=_cutoff(days)).delete(hard=True)
-
-
 ALL_JOBS = (
     animeroom_auto_logical_delete,
     animeuser_auto_logical_delete,
     animeroom_auto_hard_delete,
     animeuser_auto_hard_delete,
-    animereaction_auto_hard_delete,
 )

--- a/streamer/models.py
+++ b/streamer/models.py
@@ -55,3 +55,25 @@ class AnimeRoomHistory(models.Model):
     user_id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     room_id = models.ForeignKey(AnimeRoom, on_delete=models.CASCADE)
     type = models.CharField(max_length=20)
+
+
+class ReactionStat(models.Model):
+    """日次 × 種別に畳み込んだリアクションの集計。
+
+    リアクションは 1 タップ = 1 行（``AnimeReaction``）で大量に蓄積されるため、ルームが
+    終了する瞬間に ``cron.fold_room_reactions`` がそのルームのリアクションを日次×種別で
+    ここへ加算し、元の ``AnimeReaction`` 行はハードデリートする。これにより DB には
+    集計済みの統計だけが残り、生データは溜まらない。``(date, reaction_type)`` で一意。
+    """
+
+    date = models.DateField()
+    reaction_type = models.CharField(max_length=3, choices=ReactionType.choices)
+    count = models.PositiveIntegerField(default=0)
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["date", "reaction_type"], name="uniq_reactionstat_date_type"
+            )
+        ]
+        indexes = [models.Index(fields=["date"])]

--- a/streamer/test_stats_folding.py
+++ b/streamer/test_stats_folding.py
@@ -1,0 +1,77 @@
+"""Tests for reaction folding into ``ReactionStat`` on room end."""
+
+import datetime
+
+import pytest
+from django.utils import timezone
+
+from .cron import animeroom_auto_logical_delete, fold_room_reactions
+from .factories import AnimeRoomFactory
+from .models import AnimeReaction, AnimeRoom, ReactionStat
+
+
+def _make_reaction(room, reaction_type: str, when: datetime.datetime):
+    """Create a reaction then force ``created_at`` (``auto_now_add`` ignores it)."""
+    reaction = AnimeReaction.objects.create(room_id=room, reaction_type=reaction_type)
+    AnimeReaction.objects.filter(pk=reaction.pk).update(created_at=when)
+    return reaction
+
+
+@pytest.mark.django_db
+def test_fold_room_reactions_aggregates_and_hard_deletes():
+    """畳み込みで日次×種別に集計され、生の AnimeReaction は物理削除される。"""
+    room = AnimeRoomFactory()
+    day1 = timezone.now() - datetime.timedelta(days=2)
+    day2 = timezone.now() - datetime.timedelta(days=1)
+    _make_reaction(room, "S", day1)
+    _make_reaction(room, "S", day1)
+    _make_reaction(room, "F", day1)
+    _make_reaction(room, "S", day2)
+
+    fold_room_reactions(room.room_id)
+
+    # 生データはハードデリート済み。
+    assert AnimeReaction.objects.filter(room_id=room.room_id).count() == 0
+    # day1: S=2, F=1 / day2: S=1。
+    assert ReactionStat.objects.get(date=day1.date(), reaction_type="S").count == 2
+    assert ReactionStat.objects.get(date=day1.date(), reaction_type="F").count == 1
+    assert ReactionStat.objects.get(date=day2.date(), reaction_type="S").count == 1
+
+
+@pytest.mark.django_db
+def test_fold_room_reactions_accumulates_into_existing_rows():
+    """同じ日×種別へ複数回畳み込むと count が加算される。"""
+    day = timezone.now() - datetime.timedelta(days=1)
+
+    room_a = AnimeRoomFactory()
+    _make_reaction(room_a, "TU", day)
+    _make_reaction(room_a, "TU", day)
+    fold_room_reactions(room_a.room_id)
+
+    room_b = AnimeRoomFactory()
+    _make_reaction(room_b, "TU", day)
+    fold_room_reactions(room_b.room_id)
+
+    assert ReactionStat.objects.get(date=day.date(), reaction_type="TU").count == 3
+
+
+@pytest.mark.django_db
+def test_animeroom_auto_logical_delete_folds_then_soft_deletes():
+    """放置クリーンアップが、論理削除の前にリアクションを畳み込む。
+
+    cron は ``LOGICAL_DIVIDE_DAY``（既定 3 日）より古い ``updated_at`` を対象にする。
+    """
+    old = timezone.now() - datetime.timedelta(days=10)
+    room = AnimeRoomFactory()
+    # updated_at も auto_now なので明示的に過去へ更新し、クリーンアップ対象にする。
+    AnimeRoom.objects.filter(pk=room.pk).update(updated_at=old)
+    _make_reaction(room, "C", old)
+    _make_reaction(room, "C", old)
+
+    animeroom_auto_logical_delete()
+
+    assert AnimeReaction.objects.filter(room_id=room.room_id).count() == 0
+    assert ReactionStat.objects.get(date=old.date(), reaction_type="C").count == 2
+    # ルーム自体は論理削除（dead）になっている。
+    assert AnimeRoom.objects.alive().filter(room_id=room.room_id).exists() is False
+    assert AnimeRoom.objects.filter(room_id=room.room_id).exists() is True

--- a/streamer/tests.py
+++ b/streamer/tests.py
@@ -7,7 +7,7 @@ from django.test import TransactionTestCase
 
 from .consumers import AnimePartyConsumer
 from .factories import AnimeRoomFactory, AnimeUserFactory
-from .models import AnimeRoom, AnimeUser
+from .models import AnimeReaction, AnimeRoom, AnimeUser, ReactionStat
 
 
 @pytest.mark.django_db(transaction=True)
@@ -281,6 +281,63 @@ class TestAnimePartyConsumer(TransactionTestCase):
 
         # 片方のみ切断する（num_people の二重 decrement による CHECK 制約違反を避ける）。
         await host.disconnect()
+
+    @pytest.mark.django_db(transaction=True)
+    @pytest.mark.asyncio
+    async def test_delete_room_folds_reactions_into_stats(self):
+        """ホストの delete_room 時に、ルームのリアクションが ReactionStat へ
+        畳み込まれ、生の AnimeReaction が物理削除されるテスト。"""
+        host = WebsocketCommunicator(
+            AnimePartyConsumer.as_asgi(), "/anime-store/party/"
+        )
+        await host.connect()
+        await host.send_json_to(
+            {
+                "action": "create",
+                "user_name": "host_user",
+                "part_id": "123456",
+                "request_id": 100,
+            }
+        )
+        create_response = await host.receive_json_from()
+        room_id = create_response["room_id"]
+        await host.receive_json_from()  # create 直後の user_list を読み飛ばす。
+
+        # MIRROR な test DB は他テストの ReactionStat 行が残りうるため差分で検証する。
+        baseline = await self.smile_stat_total()
+
+        # ホストがリアクションを送る（自分の group_send は届かないため受信しない）。
+        await host.send_json_to(
+            {"action": "reaction", "reaction_type": "smile", "request_id": 100}
+        )
+        await host.send_json_to(
+            {"action": "reaction", "reaction_type": "smile", "request_id": 100}
+        )
+
+        # ルーム削除を要求し、room_deleted を待って畳み込み完了を保証する。
+        await host.send_json_to({"action": "delete_room", "request_id": 100})
+        host_msg = await host.receive_json_from()
+        assert host_msg["message_type"] == "room_deleted"
+
+        assert await self.reaction_rows(room_id) == 0
+        assert await self.smile_stat_total() - baseline == 2
+
+        await host.disconnect()
+
+    @database_sync_to_async
+    def reaction_rows(self, room_id):
+        return AnimeReaction.objects.filter(room_id=room_id).count()
+
+    @database_sync_to_async
+    def smile_stat_total(self):
+        from django.db.models import Sum
+
+        return (
+            ReactionStat.objects.filter(reaction_type="S").aggregate(t=Sum("count"))[
+                "t"
+            ]
+            or 0
+        )
 
     @database_sync_to_async
     def room_alive(self, room_id):


### PR DESCRIPTION
## 概要

リアクションは 1 タップ = 1 行（`AnimeReaction`）で大量に蓄積されるため、**ルーム終了時に
日次×種別へ畳み込み**、生データは破棄する集計モデルを導入する。あわせて**統計 API の
レスポンスを Redis にキャッシュ**し、毎リクエストの DB 集計を避ける。

## 変更点

- `models.ReactionStat`: `(date, reaction_type)` 一意の日次集計（`count` 加算 / `date` index）
- `cron.fold_room_reactions`: ルーム終了（host 削除 / 猶予期間削除 / 保持期間切れ）時に
  当該ルームのリアクションを `ReactionStat` へ加算し、`AnimeReaction` を hard delete
- `consumers`: ルーム終了経路で畳み込みを呼ぶ
- `api/views`: 統計 API を `ReactionStat` 参照＋キャッシュ化
- `settings.CACHES`: channel layer(DB0) と分けて Redis **DB1** を使用
- `.env.django`: `STATS_CACHE_SECONDS` 追加、不要になった `REACTION_HARD_DIVIDE_DAY` を削除
- `tests`: `test_stats_folding.py` 追加、api/streamer のテスト拡充

> migrations は本リポジトリの方針どおり gitignore（各環境で `makemigrations` 生成）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)