### PR TITLE
fix: force pure-Python autobahn build on arm64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,11 @@ RUN apt-get update \
 
 # Install dependencies first for better layer caching.
 COPY pyproject.toml uv.lock ./
+# autobahn (daphne 経由) は NVX CFFI 拡張のコンパイルに失敗すると pure-Python
+# wheel へのフォールバックを拒否する。arm64 ネイティブビルドでこれに当たるため、
+# pure-Python ビルドを明示する（NVX は UTF-8 検証の最適化にすぎず挙動は同じ）。
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen --no-install-project
+    AUTOBAHN_USE_NVX=0 uv sync --frozen --no-install-project
 
 COPY . .
 


### PR DESCRIPTION
## 背景
Raspberry Pi (arm64) の k3s 上で BuildKit ネイティブビルドすると、`uv sync` が
autobahn の NVX CFFI 拡張のコンパイル失敗で停止する。autobahn は pure-Python wheel
へのフォールバックを拒否するため、ビルドが通らない。

## 変更
Dockerfile の依存インストールステップで `AUTOBAHN_USE_NVX=0` を指定し、pure-Python
ビルドを強制する。NVX は UTF-8 検証の最適化であり、WebSocket プロトコルの挙動は不変。
ビルド時ステップにスコープを絞り、実行時 env は汚さない。

## 責任範囲
arm64 は本プロジェクトの公式デプロイ対象 (deploy/README.md)。イメージのビルド可否は
backend Dockerfile の責任であり、deploy 層は「イメージ無改変」が方針のためここが正しい置き場所。

## 検証
- arm64 で `docker build .` / BuildKit Job が成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)