### PR TITLE
chore: build & push arm64 release image to GHCR on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,3 +69,30 @@ jobs:
           body: ${{ github.event.inputs.release_note }}
           generate_release_notes: true
           target_commitish: main
+
+  # release ジョブが push した `vX.Y.Z` タグの commit を native arm64 でビルドし、
+  # GHCR(public) へ push する（prod-kube / Argo CD の配信元）。backend は設定を
+  # すべて runtime env で読むため build-args は不要。初回 push 後に GHCR Package
+  # を一度だけ Public にすること。
+  build-push:
+    needs: release
+    runs-on: ubuntu-24.04-arm           # native arm64 (no QEMU)
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: v${{ github.event.inputs.version }}
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/arm64
+          push: true
+          # version 入力からタグを直接組み立てる（git タグと完全一致・`v` 付き）。
+          tags: ghcr.io/d-party/backend:v${{ github.event.inputs.version }}


### PR DESCRIPTION
## What
GitOps 自動デプロイ化の backend 側の変更。

既存の `release` ワークフローに arm64 ネイティブの `build-push` ジョブ（`needs: release`）を追加し、release ジョブが push した `vX.Y.Z` タグの commit をビルドして `ghcr.io/d-party/backend:vX.Y.Z` を公開する。

- イメージタグは `version` 入力から直接組み立てるため git タグと完全一致（`v` 付き、`docker/metadata-action` の semver 正規化を経由しない）。
- backend は設定をすべて runtime env で読むため build-args 不要。
- `packages: write` は `build-push` ジョブにのみ付与（`release` ジョブは無変更）。

初回 push 後に GHCR Package を一度だけ Public にする運用が必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)