### PR TITLE
feat(reaction): broadcast sender user; skip persistence for extra reaction ids

### DIFF
--- a/streamer/consumers.py
+++ b/streamer/consumers.py
@@ -299,10 +299,18 @@ class AnimePartyConsumer(GenericAsyncAPIConsumer):
 
         Args:
             reaction_type (str): リアクションの種類
+
+        デフォルトリアクション（``ReactionType`` のメンバ）はブロードキャストに加えて
+        統計用に永続化する。拡張機能側のエクストラリアクション（Noto コードポイントの
+        id）はブロードキャストのみ行い、**永続化しない**（統計対象外）。これにより
+        未知の id でも ``ReactionType[...]`` の ``KeyError`` を起こさず安全に配信する。
         """
         if self.anime_room is None or self.anime_user is None:
             return
-        reaction = Reaction(reaction_type=reaction_type)
+        reaction = Reaction(
+            reaction_type=reaction_type,
+            user=User(**self.anime_user.__dict__).model_dump(),
+        )
         response_data = GroupSend(
             response=reaction, sender_channel_name=self.channel_name
         )
@@ -310,7 +318,8 @@ class AnimePartyConsumer(GenericAsyncAPIConsumer):
             str(self.anime_room.room_id),
             json.loads(json.dumps(response_data.model_dump())),
         )
-        await self.database_create_reaction(reaction_type=reaction_type)
+        if reaction_type in ReactionType.__members__:
+            await self.database_create_reaction(reaction_type=reaction_type)
 
     @action()
     async def user_list(self, **kwargs):

--- a/streamer/format.py
+++ b/streamer/format.py
@@ -97,6 +97,9 @@ class OperationNotification(ResponseBaseFormat):
 class Reaction(ResponseBaseFormat):
     action: str = "reaction"
     reaction_type: str
+    # 送信者。拡張機能の「バッジ表示」等で「ユーザー名 : リアクション」を出すため
+    # に同梱する。旧クライアントは無視する。
+    user: User
 
 
 class SyncRequest(ResponseBaseFormat):

--- a/streamer/tests.py
+++ b/streamer/tests.py
@@ -324,6 +324,61 @@ class TestAnimePartyConsumer(TransactionTestCase):
 
         await host.disconnect()
 
+    @pytest.mark.django_db(transaction=True)
+    @pytest.mark.asyncio
+    async def test_extra_reaction_broadcasts_but_is_not_persisted(self):
+        """エクストラリアクション（Noto コードポイント id）は他参加者へブロード
+        キャストされるが、統計用に永続化はされない（AnimeReaction を作らない）。"""
+        host = WebsocketCommunicator(
+            AnimePartyConsumer.as_asgi(), "/anime-store/party/"
+        )
+        await host.connect()
+        await host.send_json_to(
+            {
+                "action": "create",
+                "user_name": "host_user",
+                "part_id": "123456",
+                "request_id": 100,
+            }
+        )
+        create_response = await host.receive_json_from()
+        room_id = create_response["room_id"]
+        await host.receive_json_from()  # create 直後の user_list を読み飛ばす。
+
+        guest = WebsocketCommunicator(
+            AnimePartyConsumer.as_asgi(), "/anime-store/party/"
+        )
+        await guest.connect()
+        await guest.send_json_to(
+            {
+                "action": "join",
+                "user_name": "guest_user",
+                "room_id": room_id,
+                "part_id": "123456",
+                "request_id": 100,
+            }
+        )
+        # ゲストがエクストラリアクション（カタログ id = 絵文字コードポイント）を送る。
+        extra_id = "1f600"
+        await guest.send_json_to(
+            {"action": "reaction", "reaction_type": extra_id, "request_id": 100}
+        )
+
+        # ホストはブロードキャストを受信する（配信は従来どおり行われる）。参加に伴う
+        # user_add / user_list 等が先に届きうるので reaction が来るまで読み進める。
+        msg = await host.receive_json_from()
+        while msg["action"] != "reaction":
+            msg = await host.receive_json_from()
+        assert msg["reaction_type"] == extra_id
+        # 送信者を同梱する（バッジ表示の「ユーザー名 : リアクション」用）。
+        assert msg["user"]["user_name"] == "guest_user"
+
+        # ただし統計用の永続化はされない。
+        assert await self.reaction_rows(room_id) == 0
+
+        await guest.disconnect()
+        await host.disconnect()
+
     @database_sync_to_async
     def reaction_rows(self, room_id):
         return AnimeReaction.objects.filter(room_id=room_id).count()


### PR DESCRIPTION
## 変更概要

エクストラリアクション機能（拡張機能側 PR と対になる backend 側の変更）。

### 変更内容

#### `streamer/format.py`
- `Reaction` モデルに `user: User` フィールドを追加。
  - 拡張機能の「バッジ表示」で「ユーザー名 : リアクション」を表示するための送信者情報。
  - 旧クライアントは未知フィールドを無視するため後方互換あり。

#### `streamer/consumers.py`
- `reaction` ハンドラで `user` をブロードキャストに同梱。
- エクストラリアクション id（Noto コードポイント文字列）は `ReactionType.__members__` に存在しないため永続化をスキップし、broadcast のみ実施。
  - 旧実装では `ReactionType[unknown_id]` で `KeyError` が起き接続が切断されていた。

#### `streamer/tests.py`
- `test_extra_reaction_broadcasts_but_is_not_persisted` を追加:
  - エクストラ id が broadcast されること、および `AnimeReaction` が作成されないことを検証。
  - broadcast メッセージに `user.user_name` が含まれることも確認。

### デプロイ順序

**backend を先にデプロイする**（旧拡張機能は動作継続）。その後に拡張機能をリリース。