### PR TITLE
feat(api): add GET /api/v1/health liveness endpoint

### DIFF
--- a/api/tests.py
+++ b/api/tests.py
@@ -22,6 +22,19 @@ def _clear_reaction_tables() -> None:
     AnimeReaction.objects.all().delete(hard=True)
 
 
+class TestHealthCheckAPI(APITestCase):
+    def setUp(self) -> None:
+        self.client = APIClient()
+        self.endpoint = "/api/v1/health"
+
+    @pytest.mark.django_db
+    def test_health_check_ok_200(self):
+        """ヘルスチェックエンドポイントが 200 を返し、ボディが空であることを確認"""
+        response = self.client.get(self.endpoint)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.content == b""
+
+
 class TestVersionCheckAPI(APITestCase):
     def setUp(self) -> None:
         self.client = APIClient()

--- a/api/urls.py
+++ b/api/urls.py
@@ -4,6 +4,10 @@ from . import views
 
 urlpatterns = [
     path(
+        "v1/health",
+        views.HealthCheckAPI.as_view(),
+    ),
+    path(
         "v1/chrome-extension/version-check",
         views.ChromeExtensionVersionCheckAPI.as_view(),
     ),

--- a/api/views.py
+++ b/api/views.py
@@ -139,6 +139,15 @@ def _resample_per_day(
     return frame
 
 
+class HealthCheckAPI(APIView):
+    """Lightweight liveness probe. Returns 200 when the application is running."""
+
+    permission_classes = [AllowAny]
+
+    def get(self, request, format=None) -> Response:
+        return Response(status=status.HTTP_200_OK)
+
+
 class ChromeExtensionVersionCheckAPI(APIView):
     """Check whether a Chrome extension version is compatible with the backend."""
 


### PR DESCRIPTION
## 変更内容

- `GET /api/v1/health` エンドポイントを追加
- 200 空ボディのみを返す設計（ステータスコードだけで正常/異常を判断）
- Chrome Extension がサイドバー初回表示時にこのエンドポイントを叩き、失敗時にメンテナンス中バッジを表示する

## テスト

`TestHealthCheckAPI` を追加（200 かつボディ空を検証）