### PR TITLE
chore: serialization/pandas modernization, settings hardening, race fixes

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -4,7 +4,6 @@ import re
 import urllib.parse
 from collections import defaultdict
 
-import pandas as pd
 from django.core.cache import cache
 from django.db.models import Count, Sum
 from django.db.models.functions import TruncDate
@@ -122,21 +121,39 @@ def _per_day_counts(model, since: datetime.date | None = None) -> list[dict]:
 
 def _resample_per_day(
     rows: list[dict], since: datetime.date | None = None
-) -> pd.DataFrame:
+) -> list[dict]:
     """Fill gaps so every calendar day has a count.
 
-    The series always extends to today; when ``since`` is given it also starts
-    exactly at ``since`` (padding the leading days with zeros) so the window has
-    a fixed length regardless of when the first event happened.
+    Returns ``[{"day": date, "count": int}, ...]`` for every calendar day in the
+    window, in ascending order, padding missing days with ``0``. The series
+    always extends to today; when ``since`` is given it also starts exactly at
+    ``since`` so the window has a fixed length regardless of when the first
+    event happened.
+
+    A plain loop replaces the former ``pandas.DataFrame.asfreq`` round-trip,
+    which pulled in the heavy pandas dependency only to forward-fill zero days.
     """
     today = datetime.date.today()
-    if since is not None and (len(rows) == 0 or rows[0]["day"] != since):
-        rows = [{"day": since, "count": 0}] + rows
-    if len(rows) == 0 or rows[-1]["day"] != today:
-        rows = rows + [{"day": today, "count": 0}]
-    frame = pd.DataFrame(rows).set_index("day").asfreq("1D", fill_value=0)
-    frame["day"] = frame.index.map(lambda x: x.to_pydatetime().date())
-    return frame
+    counts = {row["day"]: int(row["count"]) for row in rows}
+    if since is not None:
+        start = since
+    elif rows:
+        start = rows[0]["day"]
+    else:
+        start = today
+    # 終端は常に今日まで伸ばす（最後のイベント日が今日より前でも 0 埋めで今日まで含める）。
+    end = max(today, start)
+    result: list[dict] = []
+    day = start
+    while day <= end:
+        result.append({"day": day, "count": counts.get(day, 0)})
+        day += datetime.timedelta(days=1)
+    return result
+
+
+def _mean_per_day(rows: list[dict]) -> float:
+    """Mean of the daily counts over the window (matches pandas ``Series.mean``)."""
+    return sum(row["count"] for row in rows) / len(rows) if rows else 0.0
 
 
 class HealthCheckAPI(APIView):
@@ -191,8 +208,7 @@ class AnimeActiveUserPerDayAPI(APIView):
         since = _since(days)
 
         def produce():
-            frame = _resample_per_day(_per_day_counts(AnimeUser, since), since)
-            return frame.to_dict(orient="records")
+            return _resample_per_day(_per_day_counts(AnimeUser, since), since)
 
         return Response({"data": _cached(f"stats:active-user-per-day:{days}", produce)})
 
@@ -210,8 +226,7 @@ class AnimeActiveRoomPerDayAPI(APIView):
         since = _since(days)
 
         def produce():
-            frame = _resample_per_day(_per_day_counts(AnimeRoom, since), since)
-            return frame.to_dict(orient="records")
+            return _resample_per_day(_per_day_counts(AnimeRoom, since), since)
 
         return Response({"data": _cached(f"stats:active-room-per-day:{days}", produce)})
 
@@ -338,8 +353,8 @@ class RoomCountShieldsAPI(_ShieldsView):
 
 class RoomCountParDayShieldsAPI(_ShieldsView):
     def shields_data(self) -> dict:
-        frame = _resample_per_day(_per_day_counts(AnimeRoom))
-        mean = "{:.2f}".format(frame["count"].mean()) + "/day"
+        rows = _resample_per_day(_per_day_counts(AnimeRoom))
+        mean = f"{_mean_per_day(rows):.2f}/day"
         return {
             "label": "Room",
             "message": mean,
@@ -355,8 +370,8 @@ class UserCountShieldsAPI(_ShieldsView):
 
 class UserCountParDayShieldsAPI(_ShieldsView):
     def shields_data(self) -> dict:
-        frame = _resample_per_day(_per_day_counts(AnimeUser))
-        mean = "{:.2f}".format(frame["count"].mean()) + "/day"
+        rows = _resample_per_day(_per_day_counts(AnimeUser))
+        mean = f"{_mean_per_day(rows):.2f}/day"
         return {
             "label": "User",
             "message": mean,

--- a/d_party/settings.py
+++ b/d_party/settings.py
@@ -29,7 +29,9 @@ DEBUG = os.environ["DEBUG"] == "1"
 
 ALLOWED_HOSTS = [os.environ["MY_DOMAIN"], "www." + os.environ["MY_DOMAIN"], "django"]
 if DEBUG:
-    ALLOWED_HOSTS += ["*"]
+    # 開発・テスト用の明示的な許可ホスト。``["*"]`` だと誤って DEBUG=1 のまま本番に
+    # 出たとき Host ヘッダインジェクションを許してしまうため、ワイルドカードは使わない。
+    ALLOWED_HOSTS += ["localhost", "127.0.0.1", "[::1]", "testserver"]
 CSRF_TRUSTED_ORIGINS = [
     "https://*." + os.environ["MY_DOMAIN"],
     "https://*.127.0.0.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ dependencies = [
     "django-extensions>=3.2.3",
     "pydantic>=2.9",
     "psycopg[binary]>=3.2",
-    "pandas>=2.2",
     "gunicorn>=23.0",
     "uvicorn[standard]>=0.34",
     "uvicorn-worker>=0.3",

--- a/streamer/consumers.py
+++ b/streamer/consumers.py
@@ -3,6 +3,7 @@ import json
 import uuid
 
 from channels.db import database_sync_to_async
+from django.db import transaction
 from djangochannelsrestframework.decorators import action
 from djangochannelsrestframework.generics import GenericAsyncAPIConsumer
 
@@ -26,7 +27,7 @@ from .format import (
     VideoOperation,
 )
 from .models import AnimeReaction, AnimeRoom, AnimeUser, ReactionType
-from .util import is_valid_uuid, uuid_json_encoder
+from .util import is_valid_uuid
 
 # ホストの WS が一瞬落ちた / タブをリロードしただけでルームが即消え
 # すると、ゲストが共有リンクを踏んだときにもう failed_join になる。
@@ -84,7 +85,6 @@ class AnimePartyConsumer(GenericAsyncAPIConsumer):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        json.JSONEncoder.default = uuid_json_encoder
         # 入室したAnimeRoomのオブジェクト
         self.anime_room = None
         # ユーザー情報
@@ -120,7 +120,7 @@ class AnimePartyConsumer(GenericAsyncAPIConsumer):
         )
         user = User(**self.anime_user.__dict__)
         create = Create(room_id=self.anime_room.room_id, user=user)
-        await self.send(text_data=json.dumps(create.model_dump()))
+        await self.send(text_data=json.dumps(create.model_dump(mode="json")))
         user_list = await self.database_user_list()
         user_list_data = UserList(user_list=user_list)
         response_data = RoomSend(
@@ -129,7 +129,7 @@ class AnimePartyConsumer(GenericAsyncAPIConsumer):
         )
         await self.channel_layer.group_send(
             str(self.anime_room.room_id),
-            json.loads(json.dumps(response_data.model_dump())),
+            response_data.model_dump(mode="json"),
         )
 
     @action()
@@ -152,7 +152,7 @@ class AnimePartyConsumer(GenericAsyncAPIConsumer):
             # 早期 return するだけで WS が開いたままになり、後続の sync_request 等が
             # self.anime_user.__dict__ で AttributeError を起こして 1011 close を招く。
             failed = ServerMessage(message_type="failed_join")
-            await self.send(text_data=json.dumps(failed.model_dump()))
+            await self.send(text_data=json.dumps(failed.model_dump(mode="json")))
             await self.close()
             return
         # このルームに猶予期間の削除予約があれば取り消す
@@ -166,7 +166,7 @@ class AnimePartyConsumer(GenericAsyncAPIConsumer):
         )
         user = User(**self.anime_user.__dict__)
         join = Join(room_id=self.anime_room.room_id, user=user)
-        await self.send(text_data=json.dumps(join.model_dump()))
+        await self.send(text_data=json.dumps(join.model_dump(mode="json")))
         user_add = UserAdd(user=user)
         response_data = GroupSend(
             response=user_add,
@@ -175,7 +175,7 @@ class AnimePartyConsumer(GenericAsyncAPIConsumer):
         await self.database_increase_num_people()
         await self.channel_layer.group_send(
             str(self.anime_room.room_id),
-            json.loads(json.dumps(response_data.model_dump())),
+            response_data.model_dump(mode="json"),
         )
         user_list = await self.database_user_list()
         user_list_data = UserList(user_list=user_list)
@@ -185,7 +185,7 @@ class AnimePartyConsumer(GenericAsyncAPIConsumer):
         )
         await self.channel_layer.group_send(
             str(self.anime_room.room_id),
-            json.loads(json.dumps(response_data.model_dump())),
+            response_data.model_dump(mode="json"),
         )
 
     @action()
@@ -226,7 +226,7 @@ class AnimePartyConsumer(GenericAsyncAPIConsumer):
             await self.database_update_room_part_id(video_operation.option.part_id)
         await self.channel_layer.group_send(
             str(self.anime_room.room_id),
-            json.loads(json.dumps(response_data.model_dump())),
+            response_data.model_dump(mode="json"),
         )
 
     @action()
@@ -244,7 +244,7 @@ class AnimePartyConsumer(GenericAsyncAPIConsumer):
         )
         await self.channel_layer.group_send(
             str(self.anime_room.room_id),
-            json.loads(json.dumps(response_data.model_dump())),
+            response_data.model_dump(mode="json"),
         )
 
     @action()
@@ -267,7 +267,7 @@ class AnimePartyConsumer(GenericAsyncAPIConsumer):
         )
         await self.channel_layer.group_send(
             str(self.anime_room.room_id),
-            json.loads(json.dumps(response_data.model_dump())),
+            response_data.model_dump(mode="json"),
         )
 
     @action()
@@ -290,7 +290,7 @@ class AnimePartyConsumer(GenericAsyncAPIConsumer):
         )
         await self.channel_layer.group_send(
             str(self.anime_room.room_id),
-            json.loads(json.dumps(response_data.model_dump())),
+            response_data.model_dump(mode="json"),
         )
 
     @action()
@@ -316,7 +316,7 @@ class AnimePartyConsumer(GenericAsyncAPIConsumer):
         )
         await self.channel_layer.group_send(
             str(self.anime_room.room_id),
-            json.loads(json.dumps(response_data.model_dump())),
+            response_data.model_dump(mode="json"),
         )
         if reaction_type in ReactionType.__members__:
             await self.database_create_reaction(reaction_type=reaction_type)
@@ -328,7 +328,7 @@ class AnimePartyConsumer(GenericAsyncAPIConsumer):
             return
         user_list = await self.database_user_list()
         response_data = UserList(user_list=user_list)
-        await self.send(text_data=json.dumps(response_data.model_dump()))
+        await self.send(text_data=json.dumps(response_data.model_dump(mode="json")))
 
     @action()
     async def delete_room(self, **kwargs):
@@ -352,7 +352,7 @@ class AnimePartyConsumer(GenericAsyncAPIConsumer):
         )
         await self.channel_layer.group_send(
             room_id_str,
-            json.loads(json.dumps(response_data.model_dump())),
+            response_data.model_dump(mode="json"),
         )
         await self.database_delete_room_and_users()
 
@@ -418,19 +418,19 @@ class AnimePartyConsumer(GenericAsyncAPIConsumer):
             # cancel される。
             _schedule_room_delete(str(self.anime_room.room_id))
         if user_count >= 1 and self.anime_user.is_host:
-            next_host = await self.database_get_next_host_or_none()
-            await self.database_host_change_user(next_host.user_id)
-            server_message = ServerMessage(message_type="host_change")
-            send_data = HostSend(
-                response=server_message, sender_channel_name=self.channel_name
-            )
-            await self.channel_layer.group_send(
-                str(self.anime_room.room_id),
-                json.loads(json.dumps(send_data.model_dump())),
-            )
+            next_host = await self.database_promote_next_host()
+            if next_host is not None:
+                server_message = ServerMessage(message_type="host_change")
+                send_data = HostSend(
+                    response=server_message, sender_channel_name=self.channel_name
+                )
+                await self.channel_layer.group_send(
+                    str(self.anime_room.room_id),
+                    send_data.model_dump(mode="json"),
+                )
         await self.channel_layer.group_send(
             str(self.anime_room.room_id),
-            json.loads(json.dumps(response_data.model_dump())),
+            response_data.model_dump(mode="json"),
         )
         user_list = await self.database_user_list()
         user_list_data = UserList(user_list=user_list)
@@ -440,7 +440,7 @@ class AnimePartyConsumer(GenericAsyncAPIConsumer):
         )
         await self.channel_layer.group_send(
             str(self.anime_room.room_id),
-            json.loads(json.dumps(response_data.model_dump())),
+            response_data.model_dump(mode="json"),
         )
         await self.channel_layer.group_discard(
             str(self.anime_room.room_id), self.channel_name
@@ -472,9 +472,8 @@ class AnimePartyConsumer(GenericAsyncAPIConsumer):
 
     @database_sync_to_async
     def database_delete_user(self):
-        """データベースからユーザーを削除する"""
+        """データベースからユーザーを削除する（論理削除）"""
         self.anime_user.delete()
-        self.anime_user.save()
 
     @database_sync_to_async
     def database_create_room(self, part_id: str, title: str = ""):
@@ -500,12 +499,6 @@ class AnimePartyConsumer(GenericAsyncAPIConsumer):
             part_id (str): 現在視聴している動画のID(dアニメストアが発行)
         """
         self.anime_room.part_id = part_id
-        self.anime_room.save()
-
-    @database_sync_to_async
-    def database_delete_room(self):
-        """ルームの論理削除を行う"""
-        self.anime_room.delete()
         self.anime_room.save()
 
     @database_sync_to_async
@@ -538,9 +531,27 @@ class AnimePartyConsumer(GenericAsyncAPIConsumer):
         self.anime_room.save()
 
     @database_sync_to_async
-    def database_get_next_host_or_none(self):
-        ar = AnimeRoom.objects.get(room_id=self.anime_room.room_id)
-        return ar.inroom.alive().earliest("created_at")
+    def database_promote_next_host(self):
+        """残った生存ユーザーのうち最古の 1 人をホストへアトミックに昇格させる。
+
+        次ホストの選定と昇格を 1 トランザクション（``select_for_update``）で行う。
+        「選定 → 昇格」の await 境界で当人が離脱し、論理削除済みの行をホストに
+        昇格させてしまう競合を防ぐ（旧実装は ``.earliest()`` で空のとき
+        ``DoesNotExist`` を投げて 1011 close を招いていた）。ルームが空なら ``None``。
+        """
+        with transaction.atomic():
+            next_user = (
+                AnimeUser.objects.select_for_update()
+                .alive()
+                .filter(room_id=self.anime_room.room_id)
+                .order_by("created_at")
+                .first()
+            )
+            if next_user is None:
+                return None
+            next_user.is_host = True
+            next_user.save(update_fields=["is_host"])
+            return next_user
 
     @database_sync_to_async
     def database_get_user_count(self):
@@ -563,13 +574,6 @@ class AnimePartyConsumer(GenericAsyncAPIConsumer):
         # 論理削除済みのルームには参加させない（旧実装は .filter() だけで deleted_at を
         # 無視していたため、削除直後のルームに join できてしまうバグがあった）。
         return AnimeRoom.objects.alive().filter(room_id=room_id).first()
-
-    @database_sync_to_async
-    def database_host_change_user(self, user_id):
-        au = AnimeUser.objects.get(user_id=user_id)
-        au.is_host = True
-        au.save()
-        return au
 
     @database_sync_to_async
     def database_renew_state(self):

--- a/streamer/mixins.py
+++ b/streamer/mixins.py
@@ -64,7 +64,8 @@ class LogicalDeletionMixin(models.Model):
         if hard:
             return super().delete(using=using, keep_parents=keep_parents)
         self.deleted_at = self.get_deleted_value()
-        return self.save()
+        self.save(using=using, update_fields=[DELETE_FLAG_FIELD])
+        return (1, {self._meta.label: 1})
 
     def revive(self, force_update=False, using=None):
         self.deleted_at = None

--- a/streamer/tests.py
+++ b/streamer/tests.py
@@ -47,9 +47,9 @@ class TestAnimePartyConsumer(TransactionTestCase):
         # 送信した user_icon が往復することを確認
         assert response["user"]["user_icon"] == user_icon1
         # userがデータベースに作られていることを確認
-        assert self.anime_user_exist(response["user"]["user_id"])
+        assert await self.anime_user_exist(response["user"]["user_id"])
         # roomがデータベースに作られていることを確認
-        assert self.anime_room_exist(response["room_id"])
+        assert await self.anime_room_exist(response["room_id"])
         # ルーム作成時に送られたタイトルが保存されていることを確認
         room = await self.get_anime_room(response["room_id"])
         assert room.title == title1
@@ -78,7 +78,7 @@ class TestAnimePartyConsumer(TransactionTestCase):
         response = await communicator.receive_json_from()
         assert response["action"] == "join"
         # userがデータベースに作られていることを確認
-        assert self.anime_user_exist(response["user"]["user_id"])
+        assert await self.anime_user_exist(response["user"]["user_id"])
         # user_icon を送らない旧拡張は既定アイコンにフォールバックする（後方互換）
         assert response["user"]["user_icon"] == "FaRegUser"
         await communicator.disconnect()

--- a/streamer/util.py
+++ b/streamer/util.py
@@ -1,4 +1,3 @@
-from json import JSONEncoder
 from uuid import UUID
 
 
@@ -28,10 +27,3 @@ def is_valid_uuid(uuid_to_test, version=4):
     except ValueError:
         return False
     return str(uuid_obj) == uuid_to_test
-
-
-def uuid_json_encoder(self, obj):
-    old_default = JSONEncoder.default
-    if isinstance(obj, UUID):
-        return str(obj)
-    return old_default(self, obj)

--- a/uv.lock
+++ b/uv.lock
@@ -350,7 +350,6 @@ dependencies = [
     { name = "djangorestframework" },
     { name = "gunicorn" },
     { name = "packaging" },
-    { name = "pandas" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pydantic" },
     { name = "python-dotenv" },
@@ -389,7 +388,6 @@ requires-dist = [
     { name = "djangorestframework", specifier = ">=3.15" },
     { name = "gunicorn", specifier = ">=23.0" },
     { name = "packaging", specifier = ">=24.2" },
-    { name = "pandas", specifier = ">=2.2" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2" },
     { name = "pydantic", specifier = ">=2.9" },
     { name = "python-dotenv", specifier = ">=1.0" },
@@ -751,106 +749,12 @@ wheels = [
 ]
 
 [[package]]
-name = "numpy"
-version = "2.4.6"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d0/ad/fed0499ce6a338d2a03ebae59cd15093910c8875328855781952abf6c2fe/numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda", size = 20735807, upload-time = "2026-05-18T23:37:14.07Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/82/bdab26d7438c6791ca31b7c024ca37c1eab8b726ba236129005cd4a06e45/numpy-2.4.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:511dbaf848decaaaf4b4ca48032619fb3138710c4bf7da7617765edad1ef96b0", size = 16684648, upload-time = "2026-05-18T23:34:29.41Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/30/a80189bcc7f5e4258b3fbc3968d909d1756f54d023299ecc39ad6fdb9ef8/numpy-2.4.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bf162abab1c1a736333192707cef898e735a5ca00f38f27eeedf44b39d9e85eb", size = 14693902, upload-time = "2026-05-18T23:34:33.013Z" },
-    { url = "https://files.pythonhosted.org/packages/97/12/70b5d0d7c15e1ebb8a6a84a8caa1d19e181d84fb58bb6d70aca29099dec1/numpy-2.4.6-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:043191bfa8eab18c776647b62723ac9dddece59743b13f49b2016094129c2b3f", size = 5198992, upload-time = "2026-05-18T23:34:36.132Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/8c/ebd2a8f8a83541f8d38cc5667e8c2b69cecfd30da6e45693e8158857d44b/numpy-2.4.6-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:6180d8b35af935aed8ece3a85e0a43f87393ae0ac87c8d2c8bd2c993f7270ef3", size = 6546944, upload-time = "2026-05-18T23:34:38.484Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/c5/7b863a97a91671a0338f4253bd3b5a3d3852f0692dae91711c9f4a10e787/numpy-2.4.6-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72fbe16c6fac95aedf5937fa873445cec2110be35d8a4e9433d7501fd98dae6b", size = 15669392, upload-time = "2026-05-18T23:34:41.257Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/9d/3584b9984ca4c047aea75214ce1a4c4c73d849bd71b604264b7f5653f8a8/numpy-2.4.6-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a7830bab239b79cda9c08c2da014761cafb48da6150e1da17ac06283f43b6089", size = 16633220, upload-time = "2026-05-18T23:34:45.075Z" },
-    { url = "https://files.pythonhosted.org/packages/05/ae/7c67fba23bd98caec7c99261f3a16072ade14813486b0282cb29846de832/numpy-2.4.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ef4aea96ce4d3b074422cb4f2f64e216bf9e213004bb58ecfdf50ea02ea8eb9a", size = 17020800, upload-time = "2026-05-18T23:34:49.065Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/5d/3b6725cb31d983c5e66916f5d36f6d7e5521129e4c4404d64f918292a5b6/numpy-2.4.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dfa20cc6ca228e6b155b11da03825975ce66aea520985dbbddf0f2a5a495c605", size = 18357600, upload-time = "2026-05-18T23:34:52.709Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/da/2ccc6c2fe8898dee01d90c75c5f5f914a23daf99e3e0f59516a08760c8b5/numpy-2.4.6-cp313-cp313-win32.whl", hash = "sha256:56b39e5e0622a09a25bf5baf62f4bcf0cb8a41ae6e2819cf49bbc5a74c083f91", size = 5961134, upload-time = "2026-05-18T23:34:55.618Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/cd/9cc4dc876fb065d5c220aae4d5e14826b2715331bb7618ce1fb07a679d99/numpy-2.4.6-cp313-cp313-win_amd64.whl", hash = "sha256:c4fc99836233ea196540b17ab0983aff60ed07941751930f5f4d05bc3b3b7359", size = 12318598, upload-time = "2026-05-18T23:34:58.928Z" },
-    { url = "https://files.pythonhosted.org/packages/39/1e/c0bcba1f8694116485fe28fd1be698c278fcda4141c5b0e53a2aed8b12a8/numpy-2.4.6-cp313-cp313-win_arm64.whl", hash = "sha256:a7c711e21628b52034bb5ab8d1bce291f752fcc5e92accc615778acee1ff4778", size = 10222272, upload-time = "2026-05-18T23:35:02.167Z" },
-    { url = "https://files.pythonhosted.org/packages/63/6d/cc5619247c8f4204e507f5883528372e4ac4bb189e579fb859a12e480b1f/numpy-2.4.6-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:112b06a867b235ef466ed3508ddf0238050df9c727cafb5301ac385b899189a1", size = 14821197, upload-time = "2026-05-18T23:35:05.468Z" },
-    { url = "https://files.pythonhosted.org/packages/00/58/f1c39161c87d9e9bed660f1ed4bafc0e403d5ec9650b6dd77aead07d489b/numpy-2.4.6-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:eaf7fa2de5c0be8ae6ff8e9bea2ccd725e980541244521d8d4b5f3354a27babe", size = 5326287, upload-time = "2026-05-18T23:35:08.693Z" },
-    { url = "https://files.pythonhosted.org/packages/af/57/3917ab0fd97f271a8694513581b8a36c655f111c446852c302f04ccdb6fc/numpy-2.4.6-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:7265a2f3d436e54ef9f2b52b5c937e6be778781bd97a590319d7348f1c1ca997", size = 6646763, upload-time = "2026-05-18T23:35:11.459Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/0f/037e64c494b67581ae18193d770adef354c41f3f2c8ebf865602d949bf8f/numpy-2.4.6-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f74a575920ab21fe304421a3fc28793d82e299cae9eccb37084e9fc7f3617c20", size = 15728070, upload-time = "2026-05-18T23:35:14.79Z" },
-    { url = "https://files.pythonhosted.org/packages/21/a6/5d2bae9c9542eb4df16dc9c46dc79c186e9bad53805dfa5399a6023c6db0/numpy-2.4.6-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ede83e07a75dd06bc501566c1eca2afc0d61677c1472ac9ad93fdee6e638a48d", size = 16681752, upload-time = "2026-05-18T23:35:18.836Z" },
-    { url = "https://files.pythonhosted.org/packages/92/14/23d1dfb410ae362cd59ce53e936b1513d545eb40db3949ced632e19a459e/numpy-2.4.6-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:68bb27509ac1b9a3443094260f6326150663b06abe40b73a2f81160623da5b67", size = 17086024, upload-time = "2026-05-18T23:35:22.52Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/6e/23595a2c642cdf3bc567877064bdd7f91c8b0038a4453cf2daf7248eafe9/numpy-2.4.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a0df0043bdb289bde1f62da130d20df23d58b45429f752bc7a8fc5325a225ecd", size = 18403398, upload-time = "2026-05-18T23:35:26.398Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/90/0ac3bc947217e66dec77e7cbc6a1979d1af70b6461b82f620d3bccd5e4c8/numpy-2.4.6-cp313-cp313t-win32.whl", hash = "sha256:29a287e0cf63ff528da061de6b9f64a4618da591ca1046aafc54062e40ca7eab", size = 6084971, upload-time = "2026-05-18T23:35:29.387Z" },
-    { url = "https://files.pythonhosted.org/packages/77/71/5673e351671a1d2bd6063b91b44f70c0affea7d1516fa7a6572941ba4aa1/numpy-2.4.6-cp313-cp313t-win_amd64.whl", hash = "sha256:25c692919ac5a01f170a3bfcd62d745b24fd095c353d50812637d6fcab442e75", size = 12458532, upload-time = "2026-05-18T23:35:32.175Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/88/19d3503c5046e688f049274b27a3ef3d771152fa80d3ba3d01a3dff61abe/numpy-2.4.6-cp313-cp313t-win_arm64.whl", hash = "sha256:1e978ec1e8bd0e0e4de6bb75de9d30cbb74db6b6a2bb727618613703ca0167dd", size = 10291881, upload-time = "2026-05-18T23:35:35.465Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/91/3ab2044d05fd16d343c5ac2e69b127f1b2854040dd20b193257c78028bd3/numpy-2.4.6-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:06ca2f61ec4385a07a6977c55ba998a4466c123642b4a32694d3128fce18c079", size = 16683458, upload-time = "2026-05-18T23:35:38.353Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/62/764ce66fa4147ae6d73071a3abf804ffe606f174618697c571acdf26a7c9/numpy-2.4.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:38efbc8de75c7a0fc1ac190162d892787f3f47b57cc291231aafee36b80982b7", size = 14704559, upload-time = "2026-05-18T23:35:42.14Z" },
-    { url = "https://files.pythonhosted.org/packages/60/61/23f27c172f022e04025b7dc2367f4d63c1a398120607ec896228649a6f48/numpy-2.4.6-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:d581b735e177fdcdce6fed8e7e8880a3fb6ee4e3653a3ac6af01c6f4c03effc5", size = 5209716, upload-time = "2026-05-18T23:35:45.377Z" },
-    { url = "https://files.pythonhosted.org/packages/03/71/21cf70dc6ea3e3acb95fc53a265b2fc248b981f0194ceb5b475271b8809d/numpy-2.4.6-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:0a041d3d761dc3c35cc56ce0351506a02bcbc25f7b169f652435141a17db9096", size = 6543947, upload-time = "2026-05-18T23:35:47.926Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/91/64288395ee1799bd2e0b04a305dce9666da90c961e1f3fe982a05ee1c036/numpy-2.4.6-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40fdc1ae7125e518ea98e53e69a4ebc27e1fd50510c47b7ea130cf21e5e1d42b", size = 15685197, upload-time = "2026-05-18T23:35:50.863Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/eb/ebffaa97dc55502df69584a8f0dcf07f69a3e0b3e2323670a2722db9aa39/numpy-2.4.6-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a2c306dea656c12c68f51f4cea133cbe78ca7435eb28c735eac1d3ebe73be6e8", size = 16638245, upload-time = "2026-05-18T23:35:54.752Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/0b/54f9da33128d7e350fab89c7455902eeae70349ee52bddb448dc4a576f45/numpy-2.4.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:33111801a01c12a8a1e3721f0a9232f8cfc8ae2c6b7098167e6f623c6073f402", size = 17036587, upload-time = "2026-05-18T23:35:58.355Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/f0/fdebc1052db1cc37c64beb22072d67cd6d1c71adca1299f53dec2b5e20d3/numpy-2.4.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ae506e6902902557576a26ff33eda8695e7ecb3cb36c3b573a0765dee114ebdb", size = 18363226, upload-time = "2026-05-18T23:36:02.845Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/b4/298628d98c72b57e57f7165ae6a481a1deaf6f3c28262a6e4c739c275930/numpy-2.4.6-cp314-cp314-win32.whl", hash = "sha256:aaf159caa35993cb1f56fb9b8e4610d35758e7ca005412eb1daa856a78c9c4b1", size = 6010196, upload-time = "2026-05-18T23:36:05.92Z" },
-    { url = "https://files.pythonhosted.org/packages/df/ac/46de6dda46478f7942f839e094970be2d4a861e005c4b3bf07c92e291a09/numpy-2.4.6-cp314-cp314-win_amd64.whl", hash = "sha256:b507f5c4c1d508876d1819b6bf9a49d365b96320b5d4993426b33a23ca4b8261", size = 12450334, upload-time = "2026-05-18T23:36:09.107Z" },
-    { url = "https://files.pythonhosted.org/packages/78/92/b8b798ac784102c0da830d2257d59358e3d3d90d1e2b3f2575dad976c5cf/numpy-2.4.6-cp314-cp314-win_arm64.whl", hash = "sha256:6f41ae150c4e32db4f3310cdaf64b1593a03dbabe29eec77fc9b50fe64061df6", size = 10495678, upload-time = "2026-05-18T23:36:12.766Z" },
-    { url = "https://files.pythonhosted.org/packages/30/34/ec28d1aa8115971537c01469ab2011ee96827930f0a124de1000cc2a7ed7/numpy-2.4.6-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ece3d2cfe132e7d51f44a832b303895e6f2d499c5e74dfbdb06ee246147a304a", size = 14823672, upload-time = "2026-05-18T23:36:16.473Z" },
-    { url = "https://files.pythonhosted.org/packages/16/bd/f6d1fede4e54e8042a7ff97bb495510f3c220f94bcd9e8b228e87c92cc0d/numpy-2.4.6-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:e3e5193ef5a3dc73bceee50f7fdc2c90dbb76c42df8d8fae3d1067a583df579e", size = 5328731, upload-time = "2026-05-18T23:36:19.767Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/f0/e105b9e2fd728a9910103884decd6951d9dd73896b914a98d9a231de02ee/numpy-2.4.6-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:17f9ade344e7d9b464a084d69bcf18fc691cb1db67c62ed80820bf4926d78f0e", size = 6649805, upload-time = "2026-05-18T23:36:22.266Z" },
-    { url = "https://files.pythonhosted.org/packages/82/dd/1206a7ca6ab15e3f02069707ca96222e202af681bb73756da7527f3cb837/numpy-2.4.6-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9cd5ffd25db4e7ba6a375693b3fc0fc1791ec636c17db3720da19bde7180ec43", size = 15730496, upload-time = "2026-05-18T23:36:25.713Z" },
-    { url = "https://files.pythonhosted.org/packages/51/e7/38d3ea825dcab85a591734decb2f6c67caa7c8367d374df1a1c3842f9b07/numpy-2.4.6-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7d92c3819208a60205a12a245c91ad70cb0a85336659b19b834205573ac8456e", size = 16679616, upload-time = "2026-05-18T23:36:29.652Z" },
-    { url = "https://files.pythonhosted.org/packages/93/b7/caabfdf53edf663e0b4eb74d7d405d83baef09eb5e83bcd32d601d72b93e/numpy-2.4.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e85b752a1e912b70eaad4fafbd4d1238007ab221de2009b9a2f5ae7461239895", size = 17085145, upload-time = "2026-05-18T23:36:33.449Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/45/68d7c33a6bcf3e5aa3bdbd57a367e6f615286dfd6482f97e8ffeb734306e/numpy-2.4.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:29cb7f67d10b479ff07c17d33e39f78c07f71c40ef30d63c153d340e96cd3fb4", size = 18403813, upload-time = "2026-05-18T23:36:37.369Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/50/0753655aa844c99cd9e018aacf76f130f1bd81d881bb74bc0aef5d73a8ba/numpy-2.4.6-cp314-cp314t-win32.whl", hash = "sha256:260a5d70215b61ab4fadf5c7baacd64821842975eea312125ed3c39a6391b063", size = 6156982, upload-time = "2026-05-18T23:36:40.817Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/d4/7c67becf668f973cb490cec3e98dfd799d866f9c989a54d355672cfa0db6/numpy-2.4.6-cp314-cp314t-win_amd64.whl", hash = "sha256:81a1cca95ed5bb92aa8b10dd2cdc9a0d3853a50fad926c28b5d7e8ea54389627", size = 12638908, upload-time = "2026-05-18T23:36:43.996Z" },
-    { url = "https://files.pythonhosted.org/packages/43/bb/e1c71a4295b1b1d1393d50dbb4f2a36283c6859d9d3892e84f00ec5a91d5/numpy-2.4.6-cp314-cp314t-win_arm64.whl", hash = "sha256:0c9136e14ed34a9e343a31c533d78a9813a69a3148332bce5e9821cb2f996e66", size = 10565867, upload-time = "2026-05-18T23:36:47.114Z" },
-]
-
-[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
-]
-
-[[package]]
-name = "pandas"
-version = "3.0.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy" },
-    { name = "python-dateutil" },
-    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f8/87/4341c6252d1c47b08768c3d25ac487362bf403f0313ddae4a2a26c9b1b4c/pandas-3.0.3.tar.gz", hash = "sha256:696a4a00a2a2a35d4e5deb3fc946641b96c944f02230e4f76137fe35d806c4fc", size = 4651414, upload-time = "2026-05-11T18:54:29.21Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c5/90/62d8302883c44308c477e222c3daf7c813a34c8e96985882fbd53d964352/pandas-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:67b3b64c11910cfa29f4e94a14d3bff9ee693b6fc76055e7cad549cee0aec5fa", size = 10331071, upload-time = "2026-05-11T18:52:58.838Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/ae/6a6493c783a101f165e4356953ba3c74d6f77f0042fa7d753da9dfbb640c/pandas-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:39436b377d56d2a2e52d0395bdbee171f01068e99af5250509aceeb929f765c7", size = 9875690, upload-time = "2026-05-11T18:53:01.431Z" },
-    { url = "https://files.pythonhosted.org/packages/62/7c/5df8e9f56c69a2769fbe9382a5ef8f2658c007e376434e1e2cbb57ad895f/pandas-3.0.3-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d4be06d68f9ddcfc645b87534911da79a8fbffc7573c80e0edcf42a5020624d8", size = 10381634, upload-time = "2026-05-11T18:53:04.393Z" },
-    { url = "https://files.pythonhosted.org/packages/99/68/1237369725aa617bb358263d535803e3053fdbc593513ec5ed9c9896b5b6/pandas-3.0.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a4eeb6830daf35a71cc09649bd823e2b542dac246cdee9614c6e4bd65028cd6a", size = 10891243, upload-time = "2026-05-11T18:53:07.643Z" },
-    { url = "https://files.pythonhosted.org/packages/25/93/77d108e8af7222b4a503ebde0e30215b1c2e4f8e53a526431890f22d5586/pandas-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1928e07221f82db493cd4af1e23c1bfca524a19a4699887975bff68f49a72bfb", size = 11388659, upload-time = "2026-05-11T18:53:10.634Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/bd/eff5b4399f332ac386c853f6cd2bd3fa2ca0061b9f36ecd9c4d7c4265649/pandas-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51b1fe551acb77dac643c6fda86084d8d446c10fe64b06a9cc29c4cc8540e7f2", size = 11942880, upload-time = "2026-05-11T18:53:13.536Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/20/559ace4200982c3887d0b86bfd0d856a2143ef8ddab63cc07934951a964c/pandas-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:a82d532a3351d435432cd913edbccaf8b8e01d4dd0e5ced5a8d2e8ecd94c7e44", size = 9757091, upload-time = "2026-05-11T18:53:16.306Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/66/69055a09fe200f29f922a3eeec4804611900b95f52d932ece3393c3c0c19/pandas-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:275c14e0fce14a2ec20eee474aecd305478ea3c1e6f6a9d8fe219a165542717e", size = 9057282, upload-time = "2026-05-11T18:53:18.768Z" },
-    { url = "https://files.pythonhosted.org/packages/57/0e/efe801b0e6811e8e650cd21b7f2608e30f08a7067e2bf6e8752b0d56ee3c/pandas-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:46997386d528eb40376ecd6b033cf4a8a1e5282580f68f43de875b78cba2199d", size = 10767016, upload-time = "2026-05-11T18:53:21.227Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/dc/eb55135a1d5f0f0519f28da1f609a206d2cad1f9c35c32d51e38dd7261ae/pandas-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:261e308dfb22448384b7580cf719d2f998fe2966c92893c3e77d14008af1f066", size = 10420210, upload-time = "2026-05-11T18:53:23.982Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/3e/b1d5d955ce33ffecb407465a60bc32769d74fcf68224b7ae67ae11d4dea4/pandas-3.0.3-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dd1a5d1def6a46002e964510bdc67c368aa0951df5d1d9f8365336f5a1f490cd", size = 10336126, upload-time = "2026-05-11T18:53:26.731Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/76/a01261711ab60a22d71b862f0de20e4c504bf80457270ad8cb42110f6abc/pandas-3.0.3-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d72828c20c6d6e83e1e22a6a3b47b326b71664112fa9705dcbccfd7a39b62085", size = 10728051, upload-time = "2026-05-11T18:53:29.125Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/21/ea191195e587b18cf682e97f433f81b2d0fbe341380e80a3e0d6e4403c8e/pandas-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:d26cbe1fcfc12e8fd900e2454163e466b2d3af84f7c75481df7683ffc073d870", size = 11350796, upload-time = "2026-05-11T18:53:32.056Z" },
-    { url = "https://files.pythonhosted.org/packages/64/69/f0eaaf54939f0e8c6768fd06be9af2cef9b36048b96dfb9e1b2c685a807e/pandas-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:3e91cec1879ada0624fc3dc9953c5cbd60208e59c0db28f540c5d6d47502422f", size = 11799741, upload-time = "2026-05-11T18:53:34.985Z" },
-    { url = "https://files.pythonhosted.org/packages/45/a4/865e0e510cae5fc2194de4db28be638952de942571ba9125934fd9c01d47/pandas-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:08d789b41f87e0905880e293cedf6197ce71fe67cc081358b1e148a491b9bd13", size = 10499958, upload-time = "2026-05-11T18:53:37.857Z" },
-    { url = "https://files.pythonhosted.org/packages/86/54/effdcc3c0ff7a08037889200e148ebe94c16c4f653be078c7b3675955df1/pandas-3.0.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:3650109c0f22879df8bd6179ab9ee3d7f1d1d4e7e0094a3f0032d9f51e2e64ac", size = 10336065, upload-time = "2026-05-11T18:53:41.099Z" },
-    { url = "https://files.pythonhosted.org/packages/68/10/bf2d6738d72748b961a3751ab89522d58c54efc36a8e1a12161216cd45cf/pandas-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:bab900348131a7db1f69a7309ef141fd5680f1487094193bcbbb61791573bf8f", size = 9926101, upload-time = "2026-05-11T18:53:43.515Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/e9/e35cf11c8a136e757b956f5f0efdcaa50aecde85ea055f1898dfc68262f3/pandas-3.0.3-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ba7e08b9ac1d54569cd1e256e3668975ed624d6826f7b68df0342b012007bddb", size = 10457553, upload-time = "2026-05-11T18:53:46.394Z" },
-    { url = "https://files.pythonhosted.org/packages/58/3b/1cdec6772bdbaf7b25dab360c59f03cadf05492dd724c6540af905389b07/pandas-3.0.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d71c63ae4ebdbf70209742096f1fc46a83a0613c99d4b23766cced9ff8cd62a", size = 10914065, upload-time = "2026-05-11T18:53:49.134Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/c2/1ef644445fcd72e3627bceec77e3560636f87ddce4ed841afe76b83b5bf9/pandas-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e3a2ec42c98ffa2565a67e08e218d06d72576d758d90facb7c00805194d8f360", size = 11459188, upload-time = "2026-05-11T18:53:52.527Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/49/4d8d4f42cbc9c4adc7a1870f269c02cbd6cd40d059622c06fb298addcbad/pandas-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:335f62418ed562cfc3c49e9e196375c28b729dcef8543abf4f9438e381bf3c76", size = 11982966, upload-time = "2026-05-11T18:53:55.043Z" },
-    { url = "https://files.pythonhosted.org/packages/38/55/792619469bab9882d8bbd5865d45a72f6478762d04a9af4bf0d08c503e95/pandas-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:3c20a521bbb85902f79f7270c80a59e1b5452d96d170c034f207181870f97ac5", size = 9876755, upload-time = "2026-05-11T18:53:58.067Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/af/33c469653b0ba03b50c3a98192d4c07f0c75c66b263ceb097fce0ee97d31/pandas-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:a2d2dff8a04f3917b55ab3910c32990f8ddf7eceba114947838cefa976a68977", size = 9198658, upload-time = "2026-05-11T18:54:00.733Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/fa/b8c257bd76b8bd060c3a9151c1fca05e9b9c5e3af5d0f549c0356f6d143d/pandas-3.0.3-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:0d589105b3c14645af1738ff279b2995102d8f7a03b0a66dc8d95550eb513e04", size = 10787242, upload-time = "2026-05-11T18:54:03.564Z" },
-    { url = "https://files.pythonhosted.org/packages/54/eb/f19206ffb0bf1919002969aa448b4702c6594845156a6f8050674855aac3/pandas-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:13fc1e853d9e04743d11ba75a985ccbc2a317fe07d8af61e445a6fd24dacd6a6", size = 10436369, upload-time = "2026-05-11T18:54:06.311Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/24/c7c39fb4fe22b71a0c2d78bf0c585c600092d85f94f086d2b3b2f6ca27e2/pandas-3.0.3-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:819959dab7bbd0049c15623fbac4e29a191b9528160a61fb1032242d8ced2d9c", size = 10358306, upload-time = "2026-05-11T18:54:09.085Z" },
-    { url = "https://files.pythonhosted.org/packages/16/ec/dd2a9eb7fa1204df88c0864164e35b228ac581062ac612ba0a67fd812e4c/pandas-3.0.3-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:60ae316d3fd75d1858d450d0db0103ea2be3e7d4a95ec2f064f7e2ae63f7b028", size = 10758394, upload-time = "2026-05-11T18:54:11.956Z" },
-    { url = "https://files.pythonhosted.org/packages/95/6e/00c61ea8e85b4f6d8d35e11852a1a4998fc7fafc91c6a602d1cc9c972d64/pandas-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bd3a518890b400d32f9023722dc9a9a5c969f00b415419a3c06c043f09bb5d7d", size = 11375717, upload-time = "2026-05-11T18:54:14.539Z" },
-    { url = "https://files.pythonhosted.org/packages/31/89/8fc1c268969fac43688d65fd92e67df24bd128d53cb4d2eee534cd307399/pandas-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9c39be2d709d01fa972a0cabc522389fceca4f3969332ba25a7d6c5802cf976a", size = 11828897, upload-time = "2026-05-11T18:54:17.146Z" },
-    { url = "https://files.pythonhosted.org/packages/56/3b/e7d20dea247a3e6dc0bd8a6953854afbedc03951def4e7371e05e7263e25/pandas-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4db8c527972a821cf5286b40ccc57642a39bc62e62022b42f99f8a67fca8c3a1", size = 10900855, upload-time = "2026-05-11T18:54:19.72Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/54/68a0978d1ef8502b8492099beaa6e7a0c1b32e3b5d4f677f5810cb08711c/pandas-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:b2c95f8bfc1ee412bf482605d7bfd30c12d1d26bd59fdd91efeef1d4718decb1", size = 9466464, upload-time = "2026-05-11T18:54:22.754Z" },
 ]
 
 [[package]]
@@ -1118,18 +1022,6 @@ wheels = [
 ]
 
 [[package]]
-name = "python-dateutil"
-version = "2.9.0.post0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
-]
-
-[[package]]
 name = "python-dotenv"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1222,15 +1114,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/61/87/ad52e2c582c0f0e7f0a1b86950494c38d67422dc0f5ed9044a5fb9569a49/service_identity-26.1.0.tar.gz", hash = "sha256:6358c52882c96e66ac4a55eb3a72c7dd4a70763f8cc6fa4e70abde2656f4bf3b", size = 42898, upload-time = "2026-05-30T12:04:55.184Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/93/eb/2433e1af4ff903499144de4846569fb3300b816179ae99a03c2f011b666a/service_identity-26.1.0-py3-none-any.whl", hash = "sha256:68c32dadbb69135fb951077677e07cd7f6031020f3a8c8f47a28cda8a0742118", size = 11370, upload-time = "2026-05-30T12:04:53.911Z" },
-]
-
-[[package]]
-name = "six"
-version = "1.17.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 概要

コードレビューに基づくモダナイズとバグ/競合修正。WebSocket プロトコルのワイヤ形式は不変です。

## 変更点

### モダナイズ
- WebSocket 送信を pydantic v2 `model_dump(mode="json")` に統一。グローバルな
  `json.JSONEncoder.default` モンキーパッチと冗長な `json.loads(json.dumps(...))`
  往復を全廃（出力は従来と**バイト単位で同一**）。
- 依存から **pandas を撤去**し、日次ギャップ埋めを純 Python のループに置換
  （`uv.lock` から numpy/pytz/tzdata 等も削減）。

### バグ / 競合修正
- `leave_party` のホスト委譲を `select_for_update` で**アトミック化**。旧実装は
  「次ホスト選定 → 昇格」の await 境界で当人が離脱すると論理削除済みの行を昇格させ、
  さらに `.earliest()` が空室時に `DoesNotExist` を投げて 1011 close を招いていた。
- 潜在的に無限再帰しうる未使用の `uuid_json_encoder` を削除。
- `LogicalDeletionMixin.delete()` が Django 標準の `(count, {label: count})` を返すよう修正。
  consumer の冗長な二重 `save()` と、未使用の `database_delete_room` を削除。
- テスト: `database_sync_to_async` ヘルパの `await` 漏れを修正（アサートがコルーチン
  オブジェクトに対する no-op になっており、"never awaited" 警告も出ていた）。

### セキュリティ
- `DEBUG` 時の `ALLOWED_HOSTS += ["*"]` を明示的な dev 許可リストへ変更
  （DEBUG=1 のまま本番に出た場合の Host ヘッダインジェクションを防止）。

## 検証

- `ruff check` / `ruff format --check`: クリーン
- `python manage.py makemigrations --check`: 変更なし
- `pytest`: **26 passed**（"never awaited" 警告も解消）
