### PR TITLE
chore: remove django-debug-toolbar

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,7 +161,7 @@ docker compose exec django python manage.py close_active_sessions
 | URL | 内容 |
 |-----|------|
 | `http://localhost` | アプリ（Nginx 経由） |
-| `http://localhost:8000` | Django 直接（debug-toolbar） |
+| `http://localhost:8000` | Django 直接 |
 | `http://localhost:8080` | Adminer（PostgreSQL 管理） |
 | `http://localhost:9090` | Prometheus |
 | `http://localhost:3000` | Grafana |

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ docker compose exec django python manage.py collectstatic --noinput
 
 ## 開発
 
-settings.py で`debug = True`においてコンテナを起動させた場合に 8000 ポートにデプロイされている Django コンテナに直接アクセスすることで、django-debug-toolbar が有効に働きます。
+settings.py で`debug = True`においてコンテナを起動させた場合に 8000 ポートにデプロイされている Django コンテナに直接アクセスすることで、Django を直叩きしてデバッグできます（debug-toolbar は撤去済み。解析は Prometheus/Grafana を利用）。
 
 ### 環境変数（dev / prod の出し分け）
 
@@ -53,7 +53,7 @@ settings.py で`debug = True`においてコンテナを起動させた場合に
 Compose 経由で注入されます（backend 単体ではなく、ルートで `docker compose` を実行する）。
 
 - **dev**（ルート `.env.dev`、`DEBUG=1`）… `entrypoint.sh` が `runserver` を起動し、
-  `localhost:8000` で django-debug-toolbar が有効。
+  `localhost:8000` で Django を直叩きできる。
 - **prod**（ルート `.env.prod`、`DEBUG=0`）… `gunicorn`（uvicorn worker）で ASGI 配信。
 
 > `manage.py` は `/env_files/.env.global` を `override=True` で読み込みます。そのため

--- a/d_party/settings.py
+++ b/d_party/settings.py
@@ -11,7 +11,6 @@ https://docs.djangoproject.com/en/4.0/ref/settings/
 """
 
 import os
-import socket
 from pathlib import Path
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -59,8 +58,6 @@ INSTALLED_APPS = [
     "streamer",
     "api",
 ]
-if DEBUG:
-    INSTALLED_APPS += ["debug_toolbar"]
 
 AUTHENTICATION_BACKENDS = [
     "axes.backends.AxesBackend",
@@ -79,8 +76,6 @@ MIDDLEWARE = [
     "axes.middleware.AxesMiddleware",
     "django_prometheus.middleware.PrometheusAfterMiddleware",
 ]
-if DEBUG:
-    MIDDLEWARE += ["debug_toolbar.middleware.DebugToolbarMiddleware"]
 
 ROOT_URLCONF = "d_party.urls"
 
@@ -309,11 +304,3 @@ if DEBUG:
 
 # django-extensions
 RUNSERVERPLUS_SERVER_ADDRESS_PORT = "0.0.0.0:8000"
-
-if DEBUG:
-    hostname, _, ips = socket.gethostbyname_ex(socket.gethostname())
-    INTERNAL_IPS = [ip[:-1] + "1" for ip in ips] + ["127.0.0.1", "10.0.2.2"]
-
-DEBUG_TOOLBAR_CONFIG = {
-    "SHOW_TOOLBAR_CALLBACK": lambda request: True,
-}

--- a/d_party/urls.py
+++ b/d_party/urls.py
@@ -26,9 +26,6 @@ urlpatterns = [
 ]
 
 if settings.DEBUG:
-    import debug_toolbar
-
-    urlpatterns += [path("__debug__/", include(debug_toolbar.urls))]
     from django.conf.urls.static import static
 
     # static() の戻り値型（django-stubs）と urlpatterns の要素型が食い違うが実行時は問題ない。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ dev = [
     "mypy>=1.13",
     "django-stubs[compatible-mypy]>=5.1",
     "djangorestframework-stubs>=3.15",
-    "django-debug-toolbar>=4.4",
     "werkzeug>=3.1",
     "pip-licenses>=5.0",
     "pipdeptree>=2.23",

--- a/uv.lock
+++ b/uv.lock
@@ -405,7 +405,6 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "django-debug-toolbar" },
     { name = "django-stubs", extra = ["compatible-mypy"] },
     { name = "djangorestframework-stubs" },
     { name = "factory-boy" },
@@ -446,7 +445,6 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "django-debug-toolbar", specifier = ">=4.4" },
     { name = "django-stubs", extras = ["compatible-mypy"], specifier = ">=5.1" },
     { name = "djangorestframework-stubs", specifier = ">=3.15" },
     { name = "factory-boy", specifier = ">=3.3" },
@@ -500,19 +498,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f0/b4/00c701a22d46288e3eb1340a1c141f5b4002572ce836a3e8d069f1e1de8a/django_axes-8.3.1.tar.gz", hash = "sha256:d57e923c0ba33cf45275253dd1313c3a3ff04bec686b38d677beb2b3d43c7bcd", size = 254715, upload-time = "2026-02-11T20:19:52.172Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/46/f6/777a5df7d5698eeb23c7c496cc268c0181f0489dbc5b5f2b235b30e5d8dd/django_axes-8.3.1-py3-none-any.whl", hash = "sha256:f7887582fd12713064f1602091ff6152752becae5e891a15bf802746cab0f51a", size = 74213, upload-time = "2026-02-11T20:19:48.646Z" },
-]
-
-[[package]]
-name = "django-debug-toolbar"
-version = "7.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "django" },
-    { name = "sqlparse" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1e/ac/3ac674f99c64bfbcd9ae3d7f5f3577f23ea52884e5ac36842e1f024dce03/django_debug_toolbar-7.0.0.tar.gz", hash = "sha256:ef7494c5b459c149e87cc2da88d86e944064945e86bd7b2d879093586b5fefbf", size = 359560, upload-time = "2026-06-19T00:21:23.346Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4b/ab/684a56624f9ed35127e203e52d2c241f3b7b70d37cfa8cb2ba4fc8e1e8d7/django_debug_toolbar-7.0.0-py3-none-any.whl", hash = "sha256:656161388ce48384276342eeb16d532113ec670816fa1546cc3753730aa51b3d", size = 302038, upload-time = "2026-06-19T00:21:21.531Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 概要

`django-debug-toolbar` を撤去します。

## 動機

- 本サービスのコアは **WebSocket(Channels)** による同時視聴同期で、debug-toolbar は WS リクエストには効かない。
- REST/管理画面のデバッグ以外に用途がなく、実利用されていない。
- リクエスト/SQL 解析は既に **Prometheus/Grafana** に集約済み。
- dev 依存とはいえ、DEBUG 分岐・専用の `INTERNAL_IPS`(socket) ブロックなど settings を膨らませていた。

## 変更点

- `pyproject.toml` / `uv.lock`: dev dependency-group から `django-debug-toolbar` を削除
- `d_party/settings.py`: `INSTALLED_APPS` / `MIDDLEWARE` への条件付き追加、`DEBUG_TOOLBAR_CONFIG`、および専用の `INTERNAL_IPS`(`import socket`) ブロックを撤去
- `d_party/urls.py`: `__debug__/` ルーティングを撤去（**DEBUG 時の static 配信は維持**）
- `README.md` / `AGENTS.md`: 記述を更新

## 影響範囲

- 公開インターフェース（WebSocket プロトコル / REST API 契約 / モデル意味論）に変更なし。
- 本番は `DEBUG=False` のため元々ロードされておらず、挙動不変。

## 確認

- `DEBUG=1` で `manage.py check` パス（残る警告は既存の axes 設定で本 PR と無関係）
- `ruff check` / `ruff format --check` パス
- `uv lock` 再生成済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)