### PR TITLE
fix(admin): use jazzmin default theme

### DIFF
--- a/d_party/settings.py
+++ b/d_party/settings.py
@@ -268,10 +268,6 @@ JAZZMIN_SETTINGS = {
     "language_chooser": False,
 }
 
-JAZZMIN_UI_TWEAKS = {
-    "theme": "darkly",
-}
-
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/4.0/howto/static-files/


### PR DESCRIPTION
## 概要

管理画面（django-jazzmin）のヘッダーが黒くつぶれて読めない問題を修正します。標準の見た目に戻します。

## 原因

`JAZZMIN_UI_TWEAKS` で `theme: "darkly"` **のみ**を指定していた。darkly（Bootswatch ダークテーマ）は背景を暗くするが、navbar の色クラスは jazzmin 既定の `navbar-white navbar-light`（＝暗い文字前提）のまま残るため、**ダーク背景 × 暗い文字**でヘッダーが視認できなくなっていた。

## 変更点

- `d_party/settings.py`: `JAZZMIN_UI_TWEAKS`（`theme: darkly`）を撤去し、jazzmin 標準テーマ（明るい AdminLTE）に戻す。

## 確認

- `manage.py check` パス（残る警告は既存の axes 設定で本 PR と無関係）
- `ruff check` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)