### PR TITLE
chore: hide unused first_name/last_name from admin User

### DIFF
--- a/streamer/admin.py
+++ b/streamer/admin.py
@@ -3,6 +3,7 @@ from django.contrib.auth.admin import GroupAdmin as BaseGroupAdmin
 from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
 from django.contrib.auth.models import Group, User
 from django.utils.timezone import now
+from django.utils.translation import gettext_lazy as _
 from unfold.admin import ModelAdmin
 from unfold.forms import AdminPasswordChangeForm, UserChangeForm, UserCreationForm
 
@@ -74,6 +75,31 @@ class UserAdmin(BaseUserAdmin, ModelAdmin):
     form = UserChangeForm
     add_form = UserCreationForm
     change_password_form = AdminPasswordChangeForm
+
+    # 一覧からも姓名列（既定の first_name / last_name）を外す。
+    list_display = ("username", "email", "is_staff")
+
+    # d-party の参加者は AnimeUser.user_name（表示名）で管理し、管理者アカウント
+    # （auth.User）の姓名（first_name / last_name）は一切使わない。カラム自体は
+    # Django 組み込みのため残るが、編集画面には出さないよう "Personal info" から
+    # 姓名を除いて email のみ残す。
+    fieldsets = (
+        (None, {"fields": ("username", "password")}),
+        (_("Personal info"), {"fields": ("email",)}),
+        (
+            _("Permissions"),
+            {
+                "fields": (
+                    "is_active",
+                    "is_staff",
+                    "is_superuser",
+                    "groups",
+                    "user_permissions",
+                ),
+            },
+        ),
+        (_("Important dates"), {"fields": ("last_login", "date_joined")}),
+    )
 
 
 @admin.register(Group)


### PR DESCRIPTION
## 概要

管理者アカウント（`django.contrib.auth.User`）の **姓名（`first_name` / `last_name`）** は d-party で一切使っていない（参加者は `AnimeUser.user_name` の表示名で扱う）。管理画面から姓名を非表示にする。

## 変更

- `UserAdmin.fieldsets` を上書きし、"Personal info" から姓名を除去（`email` のみ残す）
- `UserAdmin.list_display` を上書きし、一覧の姓名列を除去
- カラム自体は Django 組み込みのため残す（DB 変更・マイグレーションなし）

## 検証

- `uvx ruff check` … pass
- `manage.py check` … admin 設定エラーなし（`fieldsets`/`list_display` のフィールド参照を system check が検証）

🤖 Generated with [Claude Code](https://claude.com/claude-code)