### PR TITLE
feat(admin): デフォルトの並び順を created_at 降順にする

### DIFF
--- a/streamer/admin.py
+++ b/streamer/admin.py
@@ -25,6 +25,8 @@ class LogicalDeletionModelAdmin(ModelAdmin):
 
     actions = [logically_delete, revive]
     readonly_fields = ("deleted_at",)
+    # 既定は作成日時の降順（新しいものが先頭）で並べる。
+    ordering = ("-created_at",)
 
     def get_queryset(self, request):
         # Show every row (including logically deleted) in the admin.
@@ -62,6 +64,8 @@ class SettingAdmin(ModelAdmin):
         "disable_reaction",
         "updated_at",
     )
+    # 既定は作成日時の降順（新しいものが先頭）で並べる。
+    ordering = ("-created_at",)
 
 
 # django.contrib.auth の User / Group を unfold 仕様で再登録し、フォーム・変更画面の


### PR DESCRIPTION
## 概要

管理画面（Django admin / Unfold）の一覧のデフォルト並び順を **作成日時（`created_at`）の降順＝新しいものが先頭** に変更します。

これまで `ordering` 未設定だったため、各モデルは主キー（UUID）順＝実質ランダムに並んでいました。

## 変更内容

`streamer/admin.py` に `ordering = ("-created_at",)` を追加:

- `LogicalDeletionModelAdmin`（基底クラス）→ `AnimeRoom` / `AnimeUser` / `AnimeReaction` に一括適用
- `SettingAdmin`（基底を継承しないため個別に追加。列は `updated_at` だがモデルは `created_at` を持つので作成順で並ぶ）

`User` / `Group` は `created_at` を持たない（`date_joined` はあり）ため対象外です。列ヘッダをクリックすれば従来通り任意の列での並べ替えも可能です。

## 動作確認

- `python manage.py check` パス（残る警告は既存の axes 設定によるもので本変更と無関係）
- pre-commit（ruff check / format）パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)