### PR TITLE
fix(admin): show user_name instead of only user_id in AnimeUser list

### DIFF
--- a/streamer/admin.py
+++ b/streamer/admin.py
@@ -47,7 +47,10 @@ class AnimeRoomAdmin(LogicalDeletionModelAdmin):
 
 @admin.register(AnimeUser)
 class AnimeUserAdmin(LogicalDeletionModelAdmin):
-    list_display = ("user_id", "is_host", "created_at", "deleted_at")
+    # user_name は EncryptedCharField（保存時暗号化）だが from_db_value で
+    # ORM 読み込み時に透過的に復号されるため、そのまま平文で表示できる。
+    # 暗号化列のため DB 側での並べ替え・検索はできない（表示のみ）。
+    list_display = ("user_name", "user_id", "is_host", "created_at", "deleted_at")
 
 
 @admin.register(AnimeReaction)


### PR DESCRIPTION
## 概要

admin ダッシュボードの `AnimeUser` 一覧が UUID (`user_id`) のみ表示していたため、ユーザー名 (`user_name`) を表示するように変更する。

## 変更点

- `AnimeUserAdmin.list_display` に `user_name` を先頭列として追加。

## 復号について

`user_name` は `EncryptedCharField`（Fernet, 保存時暗号化）だが、`from_db_value` により ORM 読み込み時に透過的に復号される。よって `list_display` に足すだけで復号済みの平文が表示され、手動の復号処理は不要。

## 注意

- 暗号化列のため DB 側での並べ替え・検索・フィルタは不可（表示のみ）。
- `user_id`（UUID）は参照用に残置。

🤖 Generated with [Claude Code](https://claude.com/claude-code)