### PR TITLE
ci: Dependabot 設定を実態に合わせ（uv / directory 修正）、Trivy を main 限定にする

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,50 @@
 version: 2
 updates:
-  - package-ecosystem: "pip"
-    directory: "/Django"
+  # Python 依存は uv（pyproject.toml + uv.lock）で管理している。
+  # pip エコシステムでは uv.lock を更新できないため "uv" を使う。
+  # リポジトリ直下が django プロジェクトなので directory は "/"。
+  - package-ecosystem: "uv"
+    directory: "/"
     schedule:
       interval: "weekly"
       timezone: "Asia/Tokyo"
       time: "12:00"
     target-branch: main
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+    groups:
+      # 定期のバージョン更新だけまとめる。セキュリティ更新は
+      # 個別 PR のまま（applies-to: version-updates）にして、
+      # 1 件ずつ影響を確認できるようにする。
+      python-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+
   - package-ecosystem: "docker"
-    directory: "/Django"
+    directory: "/"
     schedule:
       interval: "weekly"
       timezone: "Asia/Tokyo"
       time: "12:00"
     target-branch: main
+    commit-message:
+      prefix: "chore(deps)"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      timezone: "Asia/Tokyo"
+      time: "12:00"
+    target-branch: main
+    commit-message:
+      prefix: "ci(deps)"
+    groups:
+      github-actions:
+        applies-to: version-updates
+        patterns:
+          - "*"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -73,6 +73,11 @@ jobs:
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3
   trivy:
+    # コンテナイメージのスキャンは main のみで走らせる。ベースイメージ由来の
+    # 新規 CVE で PR（Dependabot の依存更新を含む）がブロックされるのを避けるため、
+    # PR/トピックブランチの push では実行しない。定期実行（schedule）と
+    # workflow_dispatch も既定ブランチ = main なのでここで拾える。
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
## これはなに？

Dependabot が依存更新 PR を作れない状態だったのを直し、あわせて Trivy によるイメージスキャンを `main` 限定にします。

現在このリポジトリには Dependabot のアラートが 8 件（high: cryptography / sqlparse、medium・low: django 等）出ていますが、設定不備のため自動修正 PR が作られていませんでした。

## やったこと

**`.github/dependabot.yml`**

- `directory` が `/Django` を指していた（旧レイアウトの名残）。このリポジトリは**直下が django プロジェクト**なので `/` に修正。
- `package-ecosystem` を `pip` → **`uv`** に変更。依存は `pyproject.toml` + `uv.lock` で管理しており、pip エコシステムでは `uv.lock` を解決・更新できない（Dependabot の uv 対応: version updates は 2025-03 GA、security updates は 2025-12 対応）。
- `github-actions` エコシステムを追加（Actions の更新も追従）。
- 定期のバージョン更新は minor/patch をグループ化して PR 数を抑制。**セキュリティ更新は `applies-to: version-updates` によりグループ対象外**＝個別 PR のままなので、1 件ずつ影響を確認できる。

**`.github/workflows/security.yml`**

- `trivy` ジョブに `if: github.ref == 'refs/heads/main'` を追加。
- このワークフローは `on: push`（ブランチ指定なし）のため、**トピックブランチ / PR の push でも毎回イメージスキャンが走り**、ベースイメージ由来の新規 CVE が出るたびに PR が赤くなって依存更新のマージを妨げていた。
- イメージスキャンは main への push と定期実行（`schedule` / `workflow_dispatch` はいずれも既定ブランチ = main）でのみ実施する。bandit / pyt / CodeQL は従来どおり全 push で実行。

## テスト・動作確認

- [ ] テストコードを実装（設定ファイルのみのため対象外）
- [x] `dependabot.yml` の YAML 構文チェック（pre-commit の check-yaml）
- [x] `security.yml` の YAML 構文チェック。trivy 以外のジョブのトリガは無変更

## その他・備考

- マージ後、Dependabot security updates（リポジトリ設定側で有効化済み）が既存アラートに対する修正 PR を作成します。