### PR TITLE
fix(test): 統計畳み込みテストの日付をローカル日で突き合わせる（main の CI 赤を解消）

### DIFF
--- a/streamer/test_stats_folding.py
+++ b/streamer/test_stats_folding.py
@@ -17,6 +17,18 @@ def _make_reaction(room, reaction_type: str, when: datetime.datetime):
     return reaction
 
 
+def _day(when: datetime.datetime) -> datetime.date:
+    """The day bucket ``fold_room_reactions`` uses for ``when``.
+
+    ``TruncDate`` converts to the active timezone (``TIME_ZONE``, USE_TZ=True)
+    before truncating, so stats are bucketed per *local* day. ``timezone.now()``
+    is UTC-aware and its ``.date()`` is the UTC day, which differs from the
+    local day for part of each day (e.g. Asia/Tokyo from 15:00 UTC onwards) —
+    asserting on it made these tests fail depending on the time of day.
+    """
+    return timezone.localtime(when).date()
+
+
 @pytest.mark.django_db
 def test_fold_room_reactions_aggregates_and_hard_deletes():
     """畳み込みで日次×種別に集計され、生の AnimeReaction は物理削除される。"""
@@ -33,9 +45,9 @@ def test_fold_room_reactions_aggregates_and_hard_deletes():
     # 生データはハードデリート済み。
     assert AnimeReaction.objects.filter(room_id=room.room_id).count() == 0
     # day1: S=2, F=1 / day2: S=1。
-    assert ReactionStat.objects.get(date=day1.date(), reaction_type="S").count == 2
-    assert ReactionStat.objects.get(date=day1.date(), reaction_type="F").count == 1
-    assert ReactionStat.objects.get(date=day2.date(), reaction_type="S").count == 1
+    assert ReactionStat.objects.get(date=_day(day1), reaction_type="S").count == 2
+    assert ReactionStat.objects.get(date=_day(day1), reaction_type="F").count == 1
+    assert ReactionStat.objects.get(date=_day(day2), reaction_type="S").count == 1
 
 
 @pytest.mark.django_db
@@ -52,4 +64,4 @@ def test_fold_room_reactions_accumulates_into_existing_rows():
     _make_reaction(room_b, "TU", day)
     fold_room_reactions(room_b.room_id)
 
-    assert ReactionStat.objects.get(date=day.date(), reaction_type="TU").count == 3
+    assert ReactionStat.objects.get(date=_day(day), reaction_type="TU").count == 3


### PR DESCRIPTION
## これはなに？

`main` の Pytest が **2026-07-12 以降ずっと失敗**しています（[該当 run](https://github.com/d-party/backend/actions/workflows/pytest.yml?query=branch%3Amain)）。原因はテスト側の時刻依存で、**15:00 UTC 以降（= Asia/Tokyo の翌日）に必ず落ちる**不安定テストでした。

```
FAILED streamer/test_stats_folding.py::test_fold_room_reactions_aggregates_and_hard_deletes
FAILED streamer/test_stats_folding.py::test_fold_room_reactions_accumulates_into_existing_rows
    - streamer.models.ReactionStat.DoesNotExist: ReactionStat matching query does not exist.
```

依存更新 PR を含むすべての PR が赤くなってマージ判断ができないため、先に解消します。

## 原因

`fold_room_reactions` は `TruncDate("created_at")` で集計します。`USE_TZ = True` のため **`TruncDate` は有効タイムゾーン（`TIME_ZONE=Asia/Tokyo`）へ変換してから日付を切り出す**＝統計は「ローカル日」単位です。

一方テストは `timezone.now()`（UTC aware）の `.date()`、つまり **UTC 日**で `ReactionStat` を引いていました。15:00 UTC 以降は UTC 日と JST 日が 1 日ずれるため、`DoesNotExist` になります。

## やったこと

- 集計側と同じ「ローカル日」で引くヘルパー `_day()`（`timezone.localtime(when).date()`）を追加し、`ReactionStat.objects.get(date=...)` の各アサーションをそれ経由に変更。
- **テストのみの変更**で、`cron.py` / モデルなど実装の挙動は一切変えていません。

## テスト・動作確認

- [x] テストコードを実装（既存テストの修正）
- [x] 修正前のコードを現在時刻（21:00 UTC ≒ 06:00 JST）で実行 → 再現して 2 件 FAILED
- [x] 修正後 → `streamer/test_stats_folding.py` 2 件 passed
- [x] フルスイート `uv run pytest` → **36 passed**
- [x] `uvx ruff check` / `uvx ruff format --check` → クリーン

## その他・備考

- ローカル日でのバケット化は実装の意図どおり（統計は JST の日次）なので、テスト側を実装に合わせています。