### PR TITLE
chore(docker): ランタイムイメージからベースイメージ同梱の pip/setuptools を外す

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,13 @@ COPY pyproject.toml uv.lock ./
 RUN --mount=type=cache,target=/root/.cache/uv \
     AUTOBAHN_USE_NVX=0 uv sync --frozen --no-install-project
 
+# The app runs from UV_PROJECT_ENVIRONMENT (/opt/venv) and never uses the base
+# image's pip/setuptools — uv is the only installer. Drop them so their CVEs do
+# not ride along in the published image (setuptools ships an old version, and
+# pip vendors its own copy of msgpack). Note PATH puts /opt/venv/bin first, so
+# the interpreter that owns them must be addressed by absolute path.
+RUN /usr/local/bin/python -m pip uninstall --yes setuptools pip
+
 COPY . .
 
 EXPOSE 8000


### PR DESCRIPTION
## これはなに？

Trivy（`security.yml`）が本番イメージに対して **HIGH 6 件**を報告しています。うち **2 件は Dependabot のアラートには出てこないもの**で、`/opt/venv` ではなく**ベースイメージ側**の `/usr/local/lib/python3.14/site-packages` に同梱された pip 由来でした。

| package | 指摘 | 由来 |
|---|---|---|
| msgpack 1.1.2 | GHSA-6v7p-g79w-8964 (Out-of-bounds read / crash) | pip が vendoring している msgpack |
| setuptools 70.3.0 | CVE-2025-47273 (Path Traversal) | pip が vendoring している pkg_resources |

（残る 4 件は cryptography / sqlparse で、Dependabot の #199 / #198 が対応します。）

## やったこと

このイメージのインストーラは **uv だけ**で、アプリは `UV_PROJECT_ENVIRONMENT`（`/opt/venv`）から起動します（`entrypoint.sh` は `python manage.py` / `gunicorn` のみ。いずれも PATH 先頭の `/opt/venv/bin` を解決）。ランタイムに base image の pip は不要なので、`uv sync` 後に削除します。

```dockerfile
RUN /usr/local/bin/python -m pip uninstall --yes setuptools pip
```

- `PATH` は `/opt/venv/bin` を先頭に置くため、`python -m pip` と書くと **venv 側の python**（pip を持たない）を掴んでしまいます。対象インタプリタを絶対パスで指定しています。
- setuptools が入っていないベースイメージでも `WARNING: Skipping setuptools as it is not installed.` で正常終了するため、ベースイメージの中身が変わっても壊れません。

## テスト・動作確認

- [ ] テストコードを実装（Dockerfile のみのため対象外）
- [x] ローカルで `docker build` → 成功
- [x] イメージ内で `python manage.py check` → 既存の axes 警告のみで正常
- [x] `/opt/venv/bin/python` が解決されること、`/usr/local/bin/python -m pip` が消えていることを確認
- [x] Trivy（`--scanners vuln --severity HIGH,CRITICAL --ignore-unfixed`）ローカル実行
  - 変更前: **HIGH 6 件**
  - 本 PR 適用後: **HIGH 4 件**（cryptography / sqlparse のみ）
  - さらに手元で cryptography 50.0.0 / sqlparse 0.6.0 / django 5.2.17 まで上げたイメージ: **HIGH 0 件**

## その他・備考

- 本 PR + Dependabot の #198 / #199 / #200 が入れば、イメージの HIGH/CRITICAL は 0 件になります。
- 別件の申し送り: `manage.py check` が `axes.W006`（`AXES_LOCKOUT_PARAMETERS` に `ip_address` が無く、User-Agent / Cookie のローテーションでレート制限を回避できる）を出しています。本 PR のスコープ外ですが、別途対応の検討をおすすめします。