### PR TITLE
fix(deps): django 5.2.17 / sqlparse 0.6.0 へ更新して残りのアラートを解消する

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -489,16 +489,16 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "5.2.15"
+version = "5.2.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2b/e3/31722f7284c9f43333daff9aee9184678e4487adcb5506af0db8cea09ce1/django-5.2.15.tar.gz", hash = "sha256:5154a9bf84ac01dde011e367f355c07dbb329532e06810dcf3ef2af269e236e7", size = 10873669, upload-time = "2026-06-03T13:03:35.892Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/d8/43e9d000519adceb189620b6869ff88031e046df91c2e9da72f8f6918399/django-5.2.17.tar.gz", hash = "sha256:9d4d93be539a18ab80d058eb515900e10951e04c537c5a6b394fc49528d3251f", size = 10889740, upload-time = "2026-08-04T15:04:03.173Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/92/b5/38140b1643c00d5c46ce69c78e6980fd285aee223100319631bedee4f5e7/django-5.2.15-py3-none-any.whl", hash = "sha256:0eb4a9bb1853a35b0286dbc6d916bd352c8c2687195a7f2d6f80cefd840e4970", size = 8311957, upload-time = "2026-06-03T13:03:31.329Z" },
+    { url = "https://files.pythonhosted.org/packages/df/f8/ce120525ca78f12b07daf65786679c5d0b54a75285a8958d3ae55e39da35/django-5.2.17-py3-none-any.whl", hash = "sha256:f04fb3b36ee119e1af4fa1d397d5fd6cf12700f49321e84d4f4c642c5b1973db", size = 8315563, upload-time = "2026-08-04T15:03:59.1Z" },
 ]
 
 [[package]]
@@ -1401,11 +1401,11 @@ wheels = [
 
 [[package]]
 name = "sqlparse"
-version = "0.5.5"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/90/76/437d71068094df0726366574cf3432a4ed754217b436eb7429415cf2d480/sqlparse-0.5.5.tar.gz", hash = "sha256:e20d4a9b0b8585fdf63b10d30066c7c94c5d7a7ec47c889a2d83a3caa93ff28e", size = 120815, upload-time = "2025-12-19T07:17:45.073Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/d3/3f06a1006f2261d1342aefb3c71eed02f5d4ca5bdbecd86ebc12ad38306e/sqlparse-0.6.0.tar.gz", hash = "sha256:113c35c75365ab9cc9c7231d68c6428fb11c085fc8e9eb1ad659b7ddbf6cd2b9", size = 178477, upload-time = "2026-08-13T19:16:06.396Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/4b/359f28a903c13438ef59ebeee215fb25da53066db67b305c125f1c6d2a25/sqlparse-0.5.5-py3-none-any.whl", hash = "sha256:12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba", size = 46138, upload-time = "2025-12-19T07:17:46.573Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/50/f00935da0ec7cbf325f8dc4f772ae46fbc7b672dd62876e73f0a94adda57/sqlparse-0.6.0-py3-none-any.whl", hash = "sha256:b861c0288ce2fa56209a9a6412d2e066ac664b3873b89c26c9d8415e8e32996f", size = 50070, upload-time = "2026-08-13T19:16:04.062Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## これはなに？

backend に残っている Dependabot アラート **4 件**を解消します。**`uv.lock` のみの更新**で、`pyproject.toml` の制約は一切変更していません。

これで `main` の Trivy も **HIGH 0 件**になります（現在 4 件）。

| package | 解消するアラート |
|---|---|
| **django 5.2.15 → 5.2.17** | GHSA-8qcx-xf44-272x (medium, `DomainNameValidator` が改行を許容 → ヘッダインジェクション) / GHSA-crhf-3pfg-w68w (medium, `GDALRaster` のヒープ読み過ぎ) / GHSA-3h9f-r86x-qvjx (low, キャッシュミドルウェアが private レスポンスを露出) |
| **sqlparse 0.5.5 → 0.6.0** | GHSA-prg7-hcfm-mfcr / GHSA-f2ff-p2ww-7p4p / GHSA-pwgv-4x5q-6m9f (いずれも high, ReDoS・二次計算量 DoS) / GHSA-3496-9g83-7v6x (medium, 生成スニペットのバックスラッシュ未エスケープ) |

## なぜ Dependabot ではなく手で出すのか

**Dependabot がこの 2 件について正しい形の PR を出せていません。**

- **django**: version update として #209（5.2.15 → **6.1**）を出していますが、これは `django>=5.2,<6.0` を **`<7.0` に書き換える**もので、[AGENTS.md](../blob/main/AGENTS.md) の「Django 5.2 (LTS)」方針に反します。そもそもアラートの修正には **5.2 系のパッチで足ります**。
- **sqlparse**: `pyproject.toml` に書かれていない**推移的依存**（django 経由）なので、uv の version update の対象になりません。

そのため、制約を触らずロックだけを進める本 PR を出します。#209 は判断を仰ぐため開いたままにしてあります。

## ドキュメント確認

- **sqlparse 0.6.0** は「Drop support for Python 3.8 and 3.9. Python 3.10+ is now required.」が唯一の後方非互換です。本プロジェクトは Python 3.13/3.14 なので影響しません。API の削除はありません（[changelog](https://sqlparse.readthedocs.io/en/latest/changes.html)）。
- **Django 5.2.16 / 5.2.17** はセキュリティリリースで、挙動の破壊的変更はありません。

## テスト・動作確認

- [x] `uv run pytest` → **36 passed**
- [x] `uv run python manage.py makemigrations --check --dry-run` → `No changes detected`
- [x] `pyproject.toml` に差分が無いこと（制約を維持）
- [x] `docker build` + Trivy（`--scanners vuln --severity HIGH,CRITICAL --ignore-unfixed`）→ **HIGH/CRITICAL 0 件**
- [ ] UI 上で動作確認

## その他・備考

- 本 PR がマージされれば、backend の Dependabot アラートは 0 件、`main` の Trivy も 0 件になります。