### PR TITLE
chore(deps): Django 6.0 へ上げる（#209 の 6.1 は django-prometheus 未対応のため見送り）

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ WebSocket（`/anime-store/party/`）を Django へ振り分けます。
 | 項目 | 採用 |
 |---|---|
 | 言語 | Python 3.14 |
-| フレームワーク | Django 5.2 (LTS) · Channels 4 · DRF · djangochannelsrestframework |
+| フレームワーク | Django 6.0 · Channels 4 · DRF · djangochannelsrestframework |
 | ASGI | gunicorn + `uvicorn-worker`（本番） / `runserver`（dev, DEBUG=1） |
 | DB | **PostgreSQL 16**（`django-prometheus` 経由で計測） |
 | キャッシュ/レイヤ | Redis 7（`channels-redis`） |

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 [![Docker](https://img.shields.io/badge/-Docker-EEE.svg?logo=docker&style=flat)](https://www.docker.com/)
 [![Python](https://img.shields.io/badge/Python:3.13-F9DC3E.svg?logo=python&style=flat)](https://www.python.org/)
-[![Django:5.2](https://img.shields.io/badge/Django:5.2-092E20.svg?logo=django&style=flat)](https://www.djangoproject.com/)
+[![Django:6.0](https://img.shields.io/badge/Django:6.0-092E20.svg?logo=django&style=flat)](https://www.djangoproject.com/)
 [![PostgreSQL](https://img.shields.io/badge/PostgreSQL:16-336791.svg?logo=postgresql&style=flat&logoColor=white)](https://www.postgresql.org/)
 [![Nginx](https://img.shields.io/badge/-Nginx-5.svg?logo=nginx&style=flat)](https://www.nginx.co.jp/)
 [![Redis](https://img.shields.io/badge/Redis:7-511.svg?logo=redis&style=flat)](https://redis.io/)
@@ -24,7 +24,7 @@
 d-Party のバックエンド部分を担当するフォルダ
 
 > 開発・エージェント向けの詳細は [`AGENTS.md`](AGENTS.md) を参照。
-> （Python 3.13 · Django 5.2 · PostgreSQL · uv · ruff へモダナイズ済み）
+> （Python 3.13 · Django 6.0 · PostgreSQL · uv · ruff へモダナイズ済み）
 
 ## 初回起動コマンド
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "d-party backend — Django Channels powered watch-together servic
 authors = [{ name = "U-Not", email = "euno.eng@gmail.com" }]
 requires-python = ">=3.13"
 dependencies = [
-    "django>=5.2,<6.0",
+    "django>=5.2,<7.0",
     "channels>=4.2",
     "channels-redis>=4.2,<4.4",
     "redis>=5,<6",
@@ -15,7 +15,7 @@ dependencies = [
     "djangochannelsrestframework>=1.2",
     "django-unfold>=0.100",
     "django-axes>=7.0",
-    "django-prometheus>=2.3",
+    "django-prometheus>=2.5",
     "django-extensions>=3.2.3",
     "pydantic>=2.9",
     "psycopg[binary]>=3.2",

--- a/uv.lock
+++ b/uv.lock
@@ -439,11 +439,11 @@ requires-dist = [
     { name = "channels-redis", specifier = ">=4.2,<4.4" },
     { name = "cryptography", specifier = ">=44.0" },
     { name = "daphne", specifier = ">=4.1" },
-    { name = "django", specifier = ">=5.2,<6.0" },
+    { name = "django", specifier = ">=5.2,<7.0" },
     { name = "django-axes", specifier = ">=7.0" },
     { name = "django-extensions", specifier = ">=3.2.3" },
     { name = "django-filter", specifier = ">=24.3" },
-    { name = "django-prometheus", specifier = ">=2.3" },
+    { name = "django-prometheus", specifier = ">=2.5" },
     { name = "django-unfold", specifier = ">=0.100" },
     { name = "djangochannelsrestframework", specifier = ">=1.2" },
     { name = "djangorestframework", specifier = ">=3.15" },
@@ -489,16 +489,16 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "5.2.17"
+version = "6.0.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/d8/43e9d000519adceb189620b6869ff88031e046df91c2e9da72f8f6918399/django-5.2.17.tar.gz", hash = "sha256:9d4d93be539a18ab80d058eb515900e10951e04c537c5a6b394fc49528d3251f", size = 10889740, upload-time = "2026-08-04T15:04:03.173Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/28/5fee292e588dbdb782582436d1eb62ac8809ec55b98ef27f5b9676a00e9a/django-6.0.8.tar.gz", hash = "sha256:cb0bd962d27fc866f3c514b20aae6a7df56ec80b488f9899da46d675cd051526", size = 10924565, upload-time = "2026-08-04T15:03:39.469Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/f8/ce120525ca78f12b07daf65786679c5d0b54a75285a8958d3ae55e39da35/django-5.2.17-py3-none-any.whl", hash = "sha256:f04fb3b36ee119e1af4fa1d397d5fd6cf12700f49321e84d4f4c642c5b1973db", size = 8315563, upload-time = "2026-08-04T15:03:59.1Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b4/23e74d261eebfa9c8baed5e8810f09858b9afd613d1037f42ff7aa95c87f/django-6.0.8-py3-none-any.whl", hash = "sha256:9b98b7e1902e0e575ea4f42c175fc9512784f7f2580898286aee3388b322219d", size = 8376956, upload-time = "2026-08-04T15:03:35.138Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## これはなに？

Django を **5.2 (LTS) → 6.0** へ上げます。あわせて `django-prometheus` の下限を `>=2.3` → `>=2.5` に引き上げます。

Dependabot は #209 で **6.1** を提案していますが、そのままでは採れないことが分かったため、**現時点で依存一式が実際に対応している最新版**である 6.0 を採ります。

## なぜ 6.1 ではなく 6.0 なのか

`django-prometheus 2.5.0` は `Django!=5.0.*,<6.1,>=4.2` を宣言しており、**6.1 に対応していません**。6.1 を強制すると、uv は制約を満たすために `django-prometheus` を **2.4.0 へダウングレード**して解決します（実際に手元で `uv lock` を試すと `Updated django-prometheus v2.5.0 -> v2.4.0` になります）。

2.4.0 が入れるのは「対応しているから」ではなく、**Django 依存を一切宣言していないので制約が効かないだけ**です。このプロジェクトは DB バックエンドに `django_prometheus.db.backends.postgresql` を使っているため、監視レイヤを未検証の旧版へ落としてまで 6.1 にする価値はないと判断しました。

そこで:

```diff
-    "django>=5.2,<6.0",
+    "django>=5.2,<7.0",
-    "django-prometheus>=2.3",
+    "django-prometheus>=2.5",
```

**Django の上限を「django-prometheus が宣言する対応範囲」に委ねる**形にしています。これにより django-prometheus が 6.1 に対応した時点で、**Dependabot が自動的に Django を 6.1 へ上げられます**（`ignore` ルールのような手当てが不要）。

なお、#209 が pytest で落ちていた `ImportError: cannot import name 'cc_delim_re' from 'django.utils.cache'` は **#205 の DRF 3.18.0 で既に解消済み**でした（DRF 3.18.0 は 6.0 / 6.1 の classifier を持ちます）。**6.1 の障壁は django-prometheus だけ**です。

### 依存の Django 対応状況（調査結果）

| package | 宣言 | 6.0 | 6.1 |
|---|---|:-:|:-:|
| django-prometheus 2.5.0 | `>=4.2,!=5.0.*,<6.1` | ✅ | ❌ |
| djangorestframework 3.18.0 | `>=5.2` (classifier 5.2/6.0/6.1) | ✅ | ✅ |
| django-unfold 0.104.1 | classifier 5.2/6.0/6.1 | ✅ | ✅ |
| django-filter 26.1 | classifier 5.2/6.0/6.1 | ✅ | ✅ |
| django-axes 8.3.1 | `>=4.2` (classifier 〜6.0) | ✅ | — |
| channels 4.3.2 | `>=4.2` (classifier 〜6.0) | ✅ | — |

## テスト・動作確認

- [x] `uv run pytest` → **36 passed**
- [x] `manage.py check` → 既存の `axes.W006` のみ（本 PR による新規指摘なし）
- [x] `manage.py makemigrations --check --dry-run` → `No changes detected`
- [x] `uv run mypy .` → `Success: no issues found in 25 source files`
- [x] `uvx ruff check .` → `All checks passed!`
- [x] **実スタックでの WebSocket 検証**（`nginx → daphne → channels-redis → Redis`）。`conftest.py` が `InMemoryChannelLayer` へ差し替えるため pytest では通らない経路なので、モノレポの k6 loadtest を 3 シナリオ実行:

| シナリオ | 結果 |
|---|---|
| `ws_party` | `ws_errors 0` / `room_setup_success 100%` / `broadcast_latency avg 9.9ms` |
| `ws_oneway` | `one_way_enforced 100%` / `host_broadcast_ok 100%` |
| `ws_timer` | `spectate_success 100%` / `ws_errors 0` |

- [ ] UI 上で動作確認

## その他・備考

- ドキュメントの記載も更新しています（`AGENTS.md` のスタック表、`README.md` のバッジと概要）。
- **モノレポ root 側**の `AGENTS.md` / `README.md` にも「Django 5」の記載があります。そちらは別リポジトリなので本 PR の対象外です。
- 本 PR がマージされれば #209 は不要になります。