### PR TITLE
ci: GitHub Actions を更新し、あわせて reviewdog の mypy ジョブを直す（#207 の代替）

### DIFF
--- a/.github/workflows/autoblack.yml
+++ b/.github/workflows/autoblack.yml
@@ -17,9 +17,9 @@ jobs:
   ruff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
       - name: ruff format + check
         run: |
           uvx ruff format .

--- a/.github/workflows/code-quality-review.yml
+++ b/.github/workflows/code-quality-review.yml
@@ -6,14 +6,40 @@ on:
 jobs:
   mypy:
     runs-on: ubuntu-latest
+    # このジョブは reviewdog で PR にインラインコメントを付けるためのもの。
+    # 型検査そのものは mypy.yml が push で回している。django-stubs プラグインが
+    # DJANGO_SETTINGS_MODULE を import するため、mypy.yml と同じダミー env が要る
+    # （DB/Redis へ実接続はしないのでサービスコンテナは不要）。
+    env:
+      SECRET_KEY: django-insecure-ci
+      DEBUG: "1"
+      MY_DOMAIN: localhost
+      D_ANIME_STORE_DOMAIN: animestore.docomo.ne.jp
+      TIME_ZONE: Asia/Tokyo
+      LANGUAGE_CODE: ja
+      DATABASE_ENGINE: django_prometheus.db.backends.postgresql
+      DATABASE_USER: d_party
+      DATABASE_HOST: localhost
+      DATABASE_PORT: "5432"
+      POSTGRES_DB: d_party
+      POSTGRES_PASSWORD: password
+      REDIS_HOST: localhost
+      REDIS_PORT: "6379"
+      CHROME_EXTENSION_REQUIRED_VERSION: 1.0.0
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
-      - name: export requirements
-        run: |
-          uv export --no-hashes --format requirements-txt -o requirements.txt;
-      - uses: tsuyoshicho/action-mypy@v3
+        uses: astral-sh/setup-uv@v7
+      # action-mypy は v4 以降 setup_method の既定が "nothing" になり、自前では
+      # mypy を入れなくなった（v3 は入れていた）。requirements.txt を吐くだけでは
+      # mypy が PATH に無く exit 127 になるため、プロジェクトの venv を作って
+      # そこへ通す。pip install mypy ではなく uv sync にすることで、django-stubs /
+      # drf-stubs プラグインが解決できる mypy.yml と同じ環境になる。
+      - name: install dependencies
+        run: uv sync --frozen
+      - name: put the project venv on PATH
+        run: echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
+      - uses: tsuyoshicho/action-mypy@v5
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: "github-pr-review"
@@ -21,7 +47,7 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: reviewdog/action-actionlint@v1
         with:
           reporter: "github-pr-review"
@@ -29,11 +55,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: true
       - name: Setup node/npm
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "20"
       - run: |

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Lizard Runner
         uses: Uno-Takashi/Lizard-Runner@v3
         with:
@@ -19,11 +19,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: true
       - name: Setup node/npm
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "20"
       - name: install dockerlint
@@ -34,15 +34,15 @@ jobs:
   hadolint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: hadolint/hadolint-action@v2.0.0
+      - uses: actions/checkout@v7
+      - uses: hadolint/hadolint-action@v3.4.0
         with:
           dockerfile: ./Dockerfile
           ignore: "DL3008,SC2174,DL3009,DL3059,SC3009"
   dockle:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - run: |
           docker build -t backend-django .
       - name: Run Dockle
@@ -54,25 +54,25 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: reviewdog/action-actionlint@v1
   shellcheck:
     name: Shellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@master
   yamllint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: yaml-lint
         uses: ibiqlik/action-yamllint@v3
   # nginx-conf-check:
   #   runs-on: ubuntu-latest
   #   steps:
-  #     - uses: actions/checkout@v4
+  #     - uses: actions/checkout@v7
   #     - name: run docker-compose
   #       run: |
   #         docker-compose up -d

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
       - name: install dependencies
         run: uv sync --frozen
       - name: check licenses

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -27,9 +27,9 @@ jobs:
       REDIS_PORT: "6379"
       CHROME_EXTENSION_REQUIRED_VERSION: 1.0.0
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
       - name: install dependencies
         run: uv sync --frozen
       - name: run mypy

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -50,9 +50,9 @@ jobs:
       REDIS_PORT: "6379"
       CHROME_EXTENSION_REQUIRED_VERSION: 1.0.0
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
       - name: install dependencies
         run: uv sync --frozen
       # Migration files are committed to the repo, so CI must not generate
@@ -65,7 +65,7 @@ jobs:
       - name: run pytest
         run: uv run pytest --cov --cov-report=xml
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,12 +20,12 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: main
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
 
       - name: Bump version and commit
         env:
@@ -62,7 +62,7 @@ jobs:
           git push origin "refs/tags/v${VERSION}" --force
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ github.event.inputs.version }}
           name: Release v${{ github.event.inputs.version }}
@@ -81,15 +81,15 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: v${{ github.event.inputs.version }}
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/arm64

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -10,19 +10,19 @@ jobs:
   bandit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.9"
       - name: install bandit
         run: pip install bandit
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: run bandit
         run: |
           bandit . -r -o ./bandit.txt -f txt -c ./.github/bandit.yml
       - name: Archive bandit log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bandit-report
           path: ./bandit.txt
@@ -33,19 +33,19 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install moreutils -y
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.9"
       - name: install python-taint
         run: pip install python-taint
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: run pyt
         run: |
           pyt -a D -o pyt.txt .
       - name: Archive pyt log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pyt-report
           path: ./pyt.txt
@@ -63,15 +63,15 @@ jobs:
         language: ["python"]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@v4
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
   trivy:
     # コンテナイメージのスキャンは main のみで走らせる。ベースイメージ由来の
     # 新規 CVE で PR（Dependabot の依存更新を含む）がブロックされるのを避けるため、
@@ -81,7 +81,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: build image
         run: |
           docker build -t backend-django .


### PR DESCRIPTION
## これはなに？

Dependabot の #207（github-actions グループ 12 件）は、**そのままでは Code Quality Review の mypy ジョブが `exit 127` で落ちます**。原因ごと直したうえで、同じ更新を取り込みます。

## 原因

`tsuyoshicho/action-mypy` は **v4 で `setup_method` の既定が `"nothing"` に変わり、自前で mypy をインストールしなくなりました**（v3 は入れていた）。

このワークフローは `uv export` で `requirements.txt` を吐くだけで、**何もインストールしていません**でした。v3 のときは action 側が mypy を入れてくれていたので動いていましたが、v5 では `mypy` が PATH に無く command not found（127）になります。

```
Run tsuyoshicho/action-mypy@v5
##[error]Process completed with exit code 127.
```

## やったこと

`pip install mypy` を足すのではなく、**`uv sync --frozen` でプロジェクトの venv を作り、`.venv/bin` を `GITHUB_PATH` へ通す**形にしました。

```diff
-      - name: export requirements
-        run: |
-          uv export --no-hashes --format requirements-txt -o requirements.txt;
+      - name: install dependencies
+        run: uv sync --frozen
+      - name: put the project venv on PATH
+        run: echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
```

こうすることで、push で回っている `mypy.yml` と**同じ環境**になり、`django-stubs` / `drf-stubs` プラグインが解決できます（`pip install mypy` だけではプラグインが無く、別の形で壊れます）。あわせて、django-stubs が `DJANGO_SETTINGS_MODULE` を import するのに必要なダミー env を `mypy.yml` から揃えました（DB/Redis へ実接続はしないのでサービスコンテナは不要）。

### Actions の更新内容（#207 と同一）

| action | from | to |
|---|---|---|
| actions/checkout | v4 | v7 |
| actions/setup-node | v4 | v7 |
| actions/setup-python | v5 | v7 |
| actions/upload-artifact | v4 | v7 |
| astral-sh/setup-uv | v5 | v7 |
| codecov/codecov-action | v4 | v7 |
| github/codeql-action | v3 | v4 |
| softprops/action-gh-release | v2 | v3 |
| docker/build-push-action | v6 | v7 |
| docker/login-action | v3 | v4 |
| hadolint/hadolint-action | v2.0.0 | v3.4.0 |
| tsuyoshicho/action-mypy | v3 | v5 |

## テスト・動作確認

- [x] `actionlint`（全ワークフロー）→ 指摘なし
- [x] `uv sync --frozen` 後、`.venv/bin` を PATH に通した状態で `mypy .` が `Success: no issues found in 25 source files` になることを手元で確認
- [x] 各 action の参照タグが実在することを GitHub API（`git/ref/tags/<tag>`）で確認
- [x] 本 PR 自身の CI が、更新後の action 群で green になること（下の checks を参照）
- [ ] UI 上で動作確認

## その他・備考

- **本 PR がマージされれば #207 は不要になります**（同じ更新を含むため、Dependabot が自動でクローズします）。
- `release.yml`（`softprops/action-gh-release@v3`）は `workflow_dispatch` 専用なので、この PR の CI では実行されません。次回リリース時が初回実行になります。